### PR TITLE
Ajout d'un script pour importer les CSV InsertJeunes

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -16,11 +16,13 @@
     "lint": "eslint src/ tests/"
   },
   "dependencies": {
+    "axios": "0.27.2",
     "body-parser": "1.20.0",
     "boom": "7.3.0",
     "bunyan": "1.8.15",
     "bunyan-slack": "0.0.10",
     "commander": "9.2.0",
+    "csv-parse": "5.0.4",
     "dotenv": "16.0.0",
     "env-var": "7.1.1",
     "express": "4.18.1",

--- a/server/src/cli.js
+++ b/server/src/cli.js
@@ -2,6 +2,19 @@ require("dotenv").config();
 const { program: cli } = require("commander");
 const runScript = require("./common/runScript");
 const migrate = require("./jobs/migrate");
+const importInsertJeunes = require("./jobs/importInsertJeunes");
+const { createReadStream } = require("fs");
+
+cli
+  .command("importInsertJeunes")
+  .description("Importe les fichiers InsertJeunes en base")
+  .argument("[file]", "Un fichier CSV contenant les informations InsertJeunes", createReadStream)
+  .option("--millesime", "Le millesime du fichier (obligatoire si un fichier est passé en paramètre)")
+  .action((file, options = {}) => {
+    runScript(() => {
+      return importInsertJeunes({ input: file, ...options });
+    });
+  });
 
 cli
   .command("migrate")

--- a/server/src/common/collections/index.js
+++ b/server/src/common/collections/index.js
@@ -1,3 +1,4 @@
 module.exports = {
   logs: require("./logs"),
+  insertJeunes: require("./insertJeunes"),
 };

--- a/server/src/common/collections/insertJeunes.js
+++ b/server/src/common/collections/insertJeunes.js
@@ -1,0 +1,46 @@
+const { object, objectId, string, integer } = require("./schemas/jsonSchemaTypes");
+module.exports = {
+  name: "insertJeunes",
+  schema: () => {
+    return object(
+      {
+        _id: objectId(),
+        millesime: string(),
+        type: string({ enum: ["apprentissage", "pro"] }),
+        uai_de_etablissement: string(),
+        libelle_de_etablissement: string(),
+        region: object(
+          {
+            code: string(),
+            nom: string(),
+          },
+          { required: ["code", "nom"] }
+        ),
+        code_formation: string(),
+        type_de_diplome: string(),
+        libelle_de_la_formation: string(),
+        duree_de_formation: integer(),
+        diplome_renove_ou_nouveau: string(),
+        taux_de_poursuite_etudes: integer(),
+        taux_emploi_6_mois_apres_la_sortie: integer(),
+        taux_emploi_12_mois_apres_la_sortie: integer(),
+      },
+      {
+        required: [
+          "millesime",
+          "type",
+          "uai_de_etablissement",
+          "libelle_de_etablissement",
+          "region",
+          "code_formation",
+          "type_de_diplome",
+          "libelle_de_la_formation",
+          "diplome_renove_ou_nouveau",
+        ],
+      }
+    );
+  },
+  indexes: () => {
+    return [[{ millesime: 1, uai_de_etablissement: 1, code_formation: 1 }, { unique: true }]];
+  },
+};

--- a/server/src/common/regions.js
+++ b/server/src/common/regions.js
@@ -1,0 +1,322 @@
+const REGIONS = [
+  {
+    code: "00",
+    nom: "Collectivités d'outre-mer",
+    departements: [
+      { code: "987", nom: "Polynésie Française" },
+      { code: "988", nom: "Nouvelle-Calédonie" },
+      { code: "989", nom: "Île de Clipperton" },
+      { code: "984", nom: "Terres australes et antarctiques françaises" },
+      { code: "986", nom: "Wallis et Futuna" },
+      { code: "975", nom: "Saint-Pierre-et-Miquelon" },
+      { code: "977", nom: "Saint-Barthélemy" },
+      { code: "978", nom: "Saint-Martin" },
+    ],
+    academies: [
+      { code: "40", nom: "Nouvelle-Calédonie" },
+      { code: "42", nom: "Wallis et Futuna" },
+      { code: "44", nom: "Saint-Pierre-et-Miquelon" },
+      { code: "41", nom: "Polynésie Française" },
+      { code: "77", nom: "Saint-Barthélemy" },
+      { code: "78", nom: "Saint-Martin" },
+    ],
+  },
+  {
+    code: "01",
+    nom: "Guadeloupe",
+    departements: [{ code: "971", nom: "Guadeloupe" }],
+    academies: [{ code: "32", nom: "Guadeloupe" }],
+  },
+  {
+    code: "02",
+    nom: "Martinique",
+    departements: [{ code: "972", nom: "Martinique" }],
+    academies: [{ code: "31", nom: "Martinique" }],
+  },
+  {
+    code: "03",
+    nom: "Guyane",
+    departements: [{ code: "973", nom: "Guyane" }],
+    academies: [{ code: "33", nom: "Guyane" }],
+  },
+  {
+    code: "04",
+    nom: "La Réunion",
+    departements: [{ code: "974", nom: "La Réunion" }],
+    academies: [{ code: "28", nom: "La Réunion" }],
+  },
+  {
+    code: "06",
+    nom: "Mayotte",
+    departements: [{ code: "976", nom: "Mayotte" }],
+    academies: [{ code: "43", nom: "Mayotte" }],
+  },
+  {
+    code: "11",
+    nom: "Île-de-France",
+    departements: [
+      { code: "75", nom: "Paris" },
+      { code: "77", nom: "Seine-et-Marne" },
+      { code: "78", nom: "Yvelines" },
+      { code: "91", nom: "Essonne" },
+      { code: "92", nom: "Hauts-de-Seine" },
+      { code: "93", nom: "Seine-Saint-Denis" },
+      { code: "94", nom: "Val-de-Marne" },
+      { code: "95", nom: "Val-d'Oise" },
+    ],
+    academies: [
+      { code: "01", nom: "Paris" },
+      { code: "24", nom: "Créteil" },
+      { code: "25", nom: "Versailles" },
+    ],
+  },
+  {
+    code: "24",
+    nom: "Centre-Val de Loire",
+    departements: [
+      { code: "28", nom: "Eure-et-Loir" },
+      { code: "36", nom: "Indre" },
+      { code: "37", nom: "Indre-et-Loire" },
+      { code: "41", nom: "Loir-et-Cher" },
+      { code: "45", nom: "Loiret" },
+      { code: "18", nom: "Cher" },
+    ],
+    academies: [{ code: "18", nom: "Orléans-Tours" }],
+  },
+  {
+    code: "27",
+    nom: "Bourgogne-Franche-Comté",
+    departements: [
+      { code: "70", nom: "Haute-Saône" },
+      { code: "71", nom: "Saône-et-Loire" },
+      { code: "89", nom: "Yonne" },
+      { code: "90", nom: "Territoire de Belfort" },
+      { code: "39", nom: "Jura" },
+      { code: "21", nom: "Côte-d'Or" },
+      { code: "25", nom: "Doubs" },
+      { code: "58", nom: "Nièvre" },
+    ],
+    academies: [
+      { code: "07", nom: "Dijon" },
+      { code: "03", nom: "Besançon" },
+    ],
+  },
+  {
+    code: "28",
+    nom: "Normandie",
+    departements: [
+      { code: "76", nom: "Seine-Maritime" },
+      { code: "27", nom: "Eure" },
+      { code: "50", nom: "Manche" },
+      { code: "14", nom: "Calvados" },
+      { code: "61", nom: "Orne" },
+    ],
+    academies: [{ code: "70", nom: "Normandie" }],
+  },
+  {
+    code: "32",
+    nom: "Hauts-de-France",
+    departements: [
+      { code: "80", nom: "Somme" },
+      { code: "02", nom: "Aisne" },
+      { code: "59", nom: "Nord" },
+      { code: "60", nom: "Oise" },
+      { code: "62", nom: "Pas-de-Calais" },
+    ],
+    academies: [
+      { code: "20", nom: "Amiens" },
+      { code: "09", nom: "Lille" },
+    ],
+  },
+  {
+    code: "44",
+    nom: "Grand Est",
+    departements: [
+      { code: "88", nom: "Vosges" },
+      { code: "08", nom: "Ardennes" },
+      { code: "10", nom: "Aube" },
+      { code: "51", nom: "Marne" },
+      { code: "52", nom: "Haute-Marne" },
+      { code: "54", nom: "Meurthe-et-Moselle" },
+      { code: "55", nom: "Meuse" },
+      { code: "57", nom: "Moselle" },
+      { code: "67", nom: "Bas-Rhin" },
+      { code: "68", nom: "Haut-Rhin" },
+    ],
+    academies: [
+      { code: "19", nom: "Reims" },
+      { code: "12", nom: "Nancy-Metz" },
+      { code: "15", nom: "Strasbourg" },
+    ],
+  },
+  {
+    code: "52",
+    nom: "Pays de la Loire",
+    departements: [
+      { code: "72", nom: "Sarthe" },
+      { code: "85", nom: "Vendée" },
+      { code: "44", nom: "Loire-Atlantique" },
+      { code: "49", nom: "Maine-et-Loire" },
+      { code: "53", nom: "Mayenne" },
+    ],
+    academies: [{ code: "17", nom: "Nantes" }],
+  },
+  {
+    code: "53",
+    nom: "Bretagne",
+    departements: [
+      { code: "29", nom: "Finistère" },
+      { code: "35", nom: "Ille-et-Vilaine" },
+      { code: "22", nom: "Côtes-d'Armor" },
+      { code: "56", nom: "Morbihan" },
+    ],
+    academies: [{ code: "14", nom: "Rennes" }],
+  },
+  {
+    code: "75",
+    nom: "Nouvelle-Aquitaine",
+    departements: [
+      { code: "79", nom: "Deux-Sèvres" },
+      { code: "86", nom: "Vienne" },
+      { code: "87", nom: "Haute-Vienne" },
+      { code: "33", nom: "Gironde" },
+      { code: "40", nom: "Landes" },
+      { code: "47", nom: "Lot-et-Garonne" },
+      { code: "16", nom: "Charente" },
+      { code: "17", nom: "Charente-Maritime" },
+      { code: "19", nom: "Corrèze" },
+      { code: "23", nom: "Creuse" },
+      { code: "24", nom: "Dordogne" },
+      { code: "64", nom: "Pyrénées-Atlantiques" },
+    ],
+    academies: [
+      { code: "13", nom: "Poitiers" },
+      { code: "22", nom: "Limoges" },
+      { code: "04", nom: "Bordeaux" },
+    ],
+  },
+  {
+    code: "76",
+    nom: "Occitanie",
+    departements: [
+      { code: "81", nom: "Tarn" },
+      { code: "82", nom: "Tarn-et-Garonne" },
+      { code: "30", nom: "Gard" },
+      { code: "31", nom: "Haute-Garonne" },
+      { code: "32", nom: "Gers" },
+      { code: "34", nom: "Hérault" },
+      { code: "46", nom: "Lot" },
+      { code: "48", nom: "Lozère" },
+      { code: "09", nom: "Ariège" },
+      { code: "11", nom: "Aude" },
+      { code: "12", nom: "Aveyron" },
+      { code: "65", nom: "Hautes-Pyrénées" },
+      { code: "66", nom: "Pyrénées-Orientales" },
+    ],
+    academies: [
+      { code: "16", nom: "Toulouse" },
+      { code: "11", nom: "Montpellier" },
+    ],
+  },
+  {
+    code: "84",
+    nom: "Auvergne-Rhône-Alpes",
+    departements: [
+      { code: "73", nom: "Savoie" },
+      { code: "74", nom: "Haute-Savoie" },
+      { code: "26", nom: "Drôme" },
+      { code: "38", nom: "Isère" },
+      { code: "42", nom: "Loire" },
+      { code: "43", nom: "Haute-Loire" },
+      { code: "01", nom: "Ain" },
+      { code: "03", nom: "Allier" },
+      { code: "07", nom: "Ardèche" },
+      { code: "15", nom: "Cantal" },
+      { code: "63", nom: "Puy-de-Dôme" },
+      { code: "69", nom: "Rhône" },
+    ],
+    academies: [
+      { code: "10", nom: "Lyon" },
+      { code: "06", nom: "Clermont-Ferrand" },
+      { code: "08", nom: "Grenoble" },
+    ],
+  },
+  {
+    code: "93",
+    nom: "Provence-Alpes-Côte d'Azur",
+    departements: [
+      { code: "83", nom: "Var" },
+      { code: "84", nom: "Vaucluse" },
+      { code: "04", nom: "Alpes-de-Haute-Provence" },
+      { code: "05", nom: "Hautes-Alpes" },
+      { code: "06", nom: "Alpes-Maritimes" },
+      { code: "13", nom: "Bouches-du-Rhône" },
+    ],
+    academies: [
+      { code: "02", nom: "Aix-Marseille" },
+      { code: "23", nom: "Nice" },
+    ],
+  },
+  {
+    code: "94",
+    nom: "Corse",
+    departements: [
+      { code: "20", nom: "Corse" },
+      { code: "2A", nom: "Corse-du-Sud" },
+      { code: "2B", nom: "Haute-Corse" },
+    ],
+    academies: [{ code: "27", nom: "Corse" }],
+  },
+];
+
+function findRegionByUai(uai) {
+  if (!uai) {
+    return null;
+  }
+
+  let metropole = ["0", "6", "7"].includes(uai.substring(0, 1));
+  let found = REGIONS.find((region) => {
+    let code = metropole ? uai.substring(1, 3) : uai.substring(0, 3);
+    return region.departements.map((d) => d.code).includes(code);
+  });
+
+  return found || null;
+}
+
+function findRegionByName(name) {
+  return (
+    REGIONS.find((region) => {
+      return (
+        region.nom
+          .normalize("NFD")
+          .replace(/[\u0300-\u036f]/g, "")
+          .toUpperCase() === name.toUpperCase()
+      );
+    }) || null
+  );
+}
+
+function findRegionByCode(code) {
+  return REGIONS.find((region) => region.code === code) || null;
+}
+
+function findRegionByCodeInsee(code) {
+  return REGIONS.find((region) => region.departements.find((d) => code.startsWith(d.code))) || null;
+}
+
+function findRegionByAcademie(code) {
+  return REGIONS.find((region) => region.academies.find((a) => a.code === code)) || null;
+}
+
+function getRegions() {
+  return REGIONS;
+}
+
+module.exports = {
+  findRegionByUai,
+  findRegionByName,
+  findRegionByCode,
+  findRegionByCodeInsee,
+  findRegionByAcademie,
+  getRegions,
+};

--- a/server/src/common/utils/csvUtils.js
+++ b/server/src/common/utils/csvUtils.js
@@ -1,0 +1,20 @@
+const { parse } = require("csv-parse");
+const { pickBy, isEmpty } = require("lodash");
+
+function parseCsv(options = {}) {
+  return parse({
+    trim: true,
+    delimiter: ";",
+    columns: true,
+    on_record: (record) => {
+      return pickBy(record, (v) => {
+        return !isEmpty(v) && v.trim().length;
+      });
+    },
+    ...options,
+  });
+}
+
+module.exports = {
+  parseCsv,
+};

--- a/server/src/common/utils/httpUtils.js
+++ b/server/src/common/utils/httpUtils.js
@@ -1,0 +1,32 @@
+const axios = require("axios");
+const { compose, transformData } = require("oleoduc");
+const logger = require("../logger").child({ context: "http" });
+
+async function _fetch(url, options = {}) {
+  let { method = "GET", ...rest } = options;
+  logger.debug(`${method} ${url}...`);
+
+  return axios.request({
+    url,
+    method,
+    ...rest,
+  });
+}
+
+async function fetchStream(url, options = {}) {
+  let response = await _fetch(url, { ...options, responseType: "stream" });
+  return compose(
+    response.data,
+    transformData((d) => d.toString())
+  );
+}
+
+async function fetchJson(url, options = {}) {
+  let response = await _fetch(url, { ...options, responseType: "json" });
+  return response.data;
+}
+
+module.exports = {
+  fetchStream,
+  fetchJson,
+};

--- a/server/src/common/utils/objectUtils.js
+++ b/server/src/common/utils/objectUtils.js
@@ -1,0 +1,9 @@
+const { pickBy, isNil } = require("lodash");
+
+function omitNil(obj) {
+  return pickBy(obj, (v) => !isNil(v));
+}
+
+module.exports = {
+  omitNil,
+};

--- a/server/src/common/utils/ovhUtils.js
+++ b/server/src/common/utils/ovhUtils.js
@@ -1,0 +1,60 @@
+// eslint-disable-next-line node/no-extraneous-require
+const axios = require("axios");
+const config = require("../../config");
+const { fetchStream } = require("./httpUtils");
+
+async function authenticate(uri) {
+  let regExp = new RegExp(/^(https:\/\/)(.+):(.+):(.+)@(.*)$/);
+
+  if (!regExp.test(uri)) {
+    throw new Error("Invalid OVH URI");
+  }
+
+  let [, protocol, user, password, tenantId, authUrl] = uri.match(regExp);
+  let response = await axios.post(`${protocol}${authUrl}`, {
+    auth: {
+      identity: {
+        tenantId,
+        methods: ["password"],
+        password: {
+          user: {
+            name: user,
+            password: password,
+            domain: {
+              name: "Default",
+            },
+          },
+        },
+      },
+    },
+  });
+
+  let token = response.headers["x-subject-token"];
+  let { endpoints } = response.data.token.catalog.find((c) => c.type === "object-store");
+  let { url: baseUrl } = endpoints.find((s) => s.region === "GRA");
+
+  return { baseUrl, token };
+}
+
+async function requestObjectAccess(path, options = {}) {
+  let storage = options.storage || config.ovh.storage.storageName;
+  let { baseUrl, token } = await authenticate(config.ovh.storage.uri);
+
+  return {
+    url: encodeURI(`${baseUrl}/${storage}${path === "/" ? "" : `/${path}`}`),
+    token,
+  };
+}
+
+module.exports = {
+  getFromStorage: async (path, options = {}) => {
+    let { url, token } = await requestObjectAccess(path, options);
+    return fetchStream(url, {
+      method: "GET",
+      headers: {
+        "X-Auth-Token": token,
+        Accept: "application/json",
+      },
+    });
+  },
+};

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -15,4 +15,10 @@ module.exports = {
       .default("mongodb://127.0.0.1:27017/trajectoires-pro?retryWrites=true&w=majority")
       .asString(),
   },
+  ovh: {
+    storage: {
+      uri: env.get("TRAJECTOIRES_PRO_OVH_STORAGE_URI").asString(),
+      storageName: env.get("TRAJECTOIRES_PRO_OVH_STORAGE_NAME").default("mna-trajectoires-pro").asString(),
+    },
+  },
 };

--- a/server/src/jobs/.keep
+++ b/server/src/jobs/.keep
@@ -1,1 +1,0 @@
-Add jobs and scripts in this folder

--- a/server/src/jobs/importInsertJeunes.js
+++ b/server/src/jobs/importInsertJeunes.js
@@ -1,0 +1,93 @@
+const { getFromStorage } = require("../common/utils/ovhUtils");
+const logger = require("../common/logger").child({ context: "import" });
+const { compose, mergeStreams, writeData, oleoduc, transformData } = require("oleoduc");
+const { parseCsv } = require("../common/utils/csvUtils");
+const { dbCollection } = require("../common/mongodb");
+const { findRegionByName } = require("../common/regions");
+const { pick } = require("lodash");
+const { omitNil } = require("../common/utils/objectUtils");
+
+function readCSV(stream) {
+  return compose(stream, parseCsv());
+}
+
+async function defaultStream() {
+  return compose(
+    mergeStreams([
+      readCSV(await getFromStorage("depp-2022-etablissement-voie-pro-sco-2020-2019-maj2-112307.csv")),
+      readCSV(await getFromStorage("depp-2022-etablissement-apprentissage-2020-2019-maj2-112304.csv")),
+    ]),
+    transformData((line) => {
+      return { ...line, millesime: "2020-2019" };
+    })
+  );
+}
+
+function asInteger(value) {
+  return value ? parseInt(value) : null;
+}
+
+async function importInsertJeunes(options = {}) {
+  let stats = { total: 0, created: 0, updated: 0, failed: 0 };
+  let stream = options.input ? readCSV(options.input) : await defaultStream();
+
+  await oleoduc(
+    stream,
+    writeData(async (line) => {
+      try {
+        stats.total++;
+
+        let codeFormation = line["Code formation apprentissage"] || line["Code formation Mefstat11"];
+        let millesime = line.millesime || options.millesime;
+        let region = findRegionByName(line["Région"]);
+        let selector = {
+          uai_de_etablissement: line["n°UAI de l'établissement"],
+          code_formation: codeFormation,
+          millesime,
+        };
+
+        let res = await dbCollection("insertJeunes").updateOne(
+          selector,
+          {
+            $setOnInsert: {
+              millesime,
+              type: line["Code formation apprentissage"] ? "apprentissage" : "pro",
+              uai_de_etablissement: line["n°UAI de l'établissement"],
+              code_formation: codeFormation,
+            },
+            $set: omitNil({
+              libelle_de_etablissement: line["Libellé de l'établissement"],
+              region: pick(region, ["code", "nom"]),
+              type_de_diplome: line["Type de diplôme"],
+              libelle_de_la_formation: line["Libellé de la formation"],
+              duree_de_formation: asInteger(line["Durée de formation (en année)"]),
+              diplome_renove_ou_nouveau: line["Diplôme renové ou nouveau"],
+              taux_de_poursuite_etudes: asInteger(line["Taux de poursuite d'études"]),
+              taux_emploi_6_mois_apres_la_sortie: asInteger(line["Taux d'emploi 6 mois après la sortie"]),
+              taux_emploi_12_mois_apres_la_sortie: asInteger(line["Taux d'emploi 12 mois après la sortie"]),
+            }),
+          },
+          { upsert: true }
+        );
+
+        if (res.upsertedCount) {
+          logger.debug(`Nouvelles données ajoutées`, selector);
+          stats.created += res.upsertedCount;
+        } else if (res.modifiedCount) {
+          stats.updated += res.modifiedCount;
+          logger.debug(`Données mis à jour`, selector);
+        } else {
+          logger.trace(`Données déjà à jour`, selector);
+        }
+      } catch (e) {
+        stats.failed++;
+        logger.error(e, `Impossible d'ajouter les données`);
+      }
+    }),
+    { parallel: 10 }
+  );
+
+  return stats;
+}
+
+module.exports = importInsertJeunes;

--- a/server/src/jobs/migrate.js
+++ b/server/src/jobs/migrate.js
@@ -2,9 +2,7 @@ const { configureIndexes, configureValidation, dbCollection } = require("../comm
 
 const VERSION = 0;
 
-async function tasks() {
-  return {};
-}
+async function tasks() {}
 
 async function _ensureMigrationCanBeRun() {
   let count = await dbCollection("migrations").count({ version: VERSION });

--- a/server/tests/jobs/importInsertJeunes-test.js
+++ b/server/tests/jobs/importInsertJeunes-test.js
@@ -1,0 +1,106 @@
+const assert = require("assert");
+const importInsertJeunes = require("../../src/jobs/importInsertJeunes");
+const { createStream } = require("../utils/testUtils");
+const { dbCollection } = require("../../src/common/mongodb");
+
+describe("importInsertJeunes", () => {
+  it("Vérifie qu'on peut ajouter les données du fichier insertJeunes (apprentissage)", async () => {
+    let input =
+      createStream(`n°UAI de l'établissement;Libellé de l'établissement;Région;Code formation apprentissage;Type de diplôme;Libellé de la formation;Durée de formation (en année);Diplôme renové ou nouveau;Taux de poursuite d'études;Taux d'emploi 6 mois après la sortie;Taux d'emploi 12 mois après la sortie
+0751234J;Centre de Formation;AUVERGNE-RHONE-ALPES;1022105;MC5;cuisinier en desserts de restaurant;1;non;42;50;58
+`);
+
+    let stats = await importInsertJeunes({ input, millesime: "2022-2021" });
+
+    assert.deepStrictEqual(stats, { created: 1, failed: 0, total: 1, updated: 0 });
+
+    let docs = await dbCollection("insertJeunes")
+      .find({}, { projection: { _id: 0 } })
+      .toArray();
+    assert.strictEqual(docs.length, 1);
+    assert.deepStrictEqual(docs[0], {
+      millesime: "2022-2021",
+      code_formation: "1022105",
+      type: "apprentissage",
+      diplome_renove_ou_nouveau: "non",
+      duree_de_formation: 1,
+      libelle_de_etablissement: "Centre de Formation",
+      libelle_de_la_formation: "cuisinier en desserts de restaurant",
+      region: {
+        code: "84",
+        nom: "Auvergne-Rhône-Alpes",
+      },
+      taux_de_poursuite_etudes: 42,
+      taux_emploi_12_mois_apres_la_sortie: 58,
+      taux_emploi_6_mois_apres_la_sortie: 50,
+      type_de_diplome: "MC5",
+      uai_de_etablissement: "0751234J",
+    });
+  });
+
+  it("Vérifie qu'on peut ajouter les données du fichier insertJeunes (pro)", async () => {
+    let input =
+      createStream(`n°UAI de l'établissement;Libellé de l'établissement;Région;Code formation Mefstat11;Type de diplôme;Libellé de la formation;Durée de formation (en année);Diplôme renové ou nouveau;Taux de poursuite d'études;Taux d'emploi 6 mois après la sortie;Taux d'emploi 12 mois après la sortie
+0751234J;Centre de Formation;ILE-DE-FRANCE;23830025007;BAC PRO;maintenance des equipements industriels;3;non;42;50;
+`);
+
+    let stats = await importInsertJeunes({ input, millesime: "2022-2021" });
+
+    assert.deepStrictEqual(stats, { created: 1, failed: 0, total: 1, updated: 0 });
+
+    let docs = await dbCollection("insertJeunes")
+      .find({}, { projection: { _id: 0 } })
+      .toArray();
+    assert.strictEqual(docs.length, 1);
+    assert.deepStrictEqual(docs[0], {
+      millesime: "2022-2021",
+      code_formation: "23830025007",
+      type: "pro",
+      diplome_renove_ou_nouveau: "non",
+      duree_de_formation: 3,
+      libelle_de_etablissement: "Centre de Formation",
+      libelle_de_la_formation: "maintenance des equipements industriels",
+      region: {
+        code: "11",
+        nom: "Île-de-France",
+      },
+      taux_de_poursuite_etudes: 42,
+      taux_emploi_6_mois_apres_la_sortie: 50,
+      type_de_diplome: "BAC PRO",
+      uai_de_etablissement: "0751234J",
+    });
+  });
+
+  it("Vérifie qu'on peut mettre à jour des données", async () => {
+    await importInsertJeunes({
+      millesime: "2022-2021",
+      input:
+        createStream(`n°UAI de l'établissement;Libellé de l'établissement;Région;Code formation Mefstat11;Type de diplôme;Libellé de la formation;Durée de formation (en année);Diplôme renové ou nouveau;Taux de poursuite d'études;Taux d'emploi 6 mois après la sortie;Taux d'emploi 12 mois après la sortie
+0751234J;Centre de Formation;ILE-DE-FRANCE;23830025007;BAC PRO;maintenance des equipements industriels;3;non;42;50;58
+`),
+    });
+
+    let stats = await importInsertJeunes({
+      millesime: "2022-2021",
+      input:
+        createStream(`n°UAI de l'établissement;Libellé de l'établissement;Région;Code formation Mefstat11;Type de diplôme;Libellé de la formation;Durée de formation (en année);Diplôme renové ou nouveau;Taux de poursuite d'études;Taux d'emploi 6 mois après la sortie;Taux d'emploi 12 mois après la sortie
+0751234J;Nouveau Centre de Formation;ILE-DE-FRANCE;23830025007;BAC PRO;maintenance des equipements industriels;3;non;42;50;58
+`),
+    });
+
+    assert.deepStrictEqual(stats, { created: 0, failed: 0, total: 1, updated: 1 });
+    let found = await dbCollection("insertJeunes").findOne();
+    assert.strictEqual(found.libelle_de_etablissement, "Nouveau Centre de Formation");
+  });
+
+  it("Vérifie qu'on gère des lignes invalides", async () => {
+    let input =
+      createStream(`n°UAI de l'établissement;Libellé de l'établissement;Région;Code formation Mefstat11;Type de diplôme;Libellé de la formation;Durée de formation (en année);Diplôme renové ou nouveau;Taux de poursuite d'études;Taux d'emploi 6 mois après la sortie;Taux d'emploi 12 mois après la sortie
+0751234J;Centre de Formation;INVALID;23830025007;BAC PRO;maintenance des equipements industriels;3;non;42;50;58
+`);
+
+    let stats = await importInsertJeunes({ input, millesime: "2022-2021" });
+
+    assert.deepStrictEqual(stats, { created: 0, failed: 1, total: 1, updated: 0 });
+  });
+});

--- a/server/tests/utils/testUtils.js
+++ b/server/tests/utils/testUtils.js
@@ -1,5 +1,6 @@
 const server = require("../../src/http/server");
 const axiosist = require("axiosist"); // eslint-disable-line node/no-unpublished-require
+const { Readable } = require("stream"); // eslint-disable-line node/no-unpublished-require
 
 async function startServer() {
   const app = await server();
@@ -10,6 +11,19 @@ async function startServer() {
   };
 }
 
+let createStream = (content) => {
+  let stream = new Readable({
+    objectMode: true,
+    read() {},
+  });
+
+  stream.push(content);
+  stream.push(null);
+
+  return stream;
+};
+
 module.exports = {
   startServer,
+  createStream,
 };

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -483,6 +483,14 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
+axios@0.27.2:
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
+  integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
+  dependencies:
+    follow-redirects "^1.14.9"
+    form-data "^4.0.0"
+
 axios@^0.21.0:
   version "0.21.4"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
@@ -839,7 +847,7 @@ colorette@^2.0.16:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.16.tgz#713b9af84fdb000139f04546bd4a93f62a5085da"
   integrity sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==
 
-combined-stream@^1.0.6, combined-stream@~1.0.6:
+combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -930,6 +938,11 @@ crypto-random-string@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
   integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
+
+csv-parse@5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/csv-parse/-/csv-parse-5.0.4.tgz#97e5e654413bcf95f2714ce09bcb2be6de0eb8e3"
+  integrity sha512-5AIdl8l6n3iYQYxan5djB5eKDa+vBnhfWZtRpJTcrETWfVLYN0WSj3L9RwvgYt+psoO77juUr8TG8qpfGZifVQ==
 
 cyclist@1.0.1, cyclist@^1.0.1:
   version "1.0.1"
@@ -1494,7 +1507,7 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-follow-redirects@^1.14.0:
+follow-redirects@^1.14.0, follow-redirects@^1.14.9:
   version "1.14.9"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
   integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
@@ -1511,6 +1524,15 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 form-data@~2.3.2:
   version "2.3.3"


### PR DESCRIPTION
Cette PR permet d'importer les fichiers insert jeunes dans l'application.

Les fichiers XLS présents sur https://www.education.gouv.fr/l-insertion-des-jeunes-apres-une-formation-en-voie-professionnelle-307956 ont été convertis au format CSV et stockés sur le storage OVH.

Pour lancer le script :

```sh
TRAJECTOIRES_PRO_LOG_LEVEL=debug yarn cli importInsertJeunes
```

Cette commande va télécharger les fichiers sur le storage, il est donc nécessaire de mettre la variable `TRAJECTOIRES_PRO_OVH_STORAGE_URI` dans `server/.env`


Il est également possible de passer un fichier CSV en ligne de commande

```sh
yarn cli importInsertJeunes --millesime 2020 /path/to/file.csv
```

