### PR TITLE
chore: refactor access to collections & type them directly

### DIFF
--- a/server/src/common/collections/index.js
+++ b/server/src/common/collections/index.js
@@ -1,5 +1,19 @@
+const { dbCollection } = require("../mongodb");
+
 module.exports = {
-  logs: require("./logs"),
-  inserJeunesNationals: require("./inserJeunesNationals"),
-  formationsStats: require("./formationsStats"),
+  /**
+   * @typedef {import("mongodb").Collection<import("./logs").Logs>} LogsCollection
+   * @returns {LogsCollection}
+   */
+  logs: () => dbCollection("logs"),
+  /**
+   * @typedef {import("mongodb").Collection<import("./inserJeunesNationals").InserJeunesNationals>}InserJeunesNationalsCollection
+   *  @returns {InserJeunesNationalsCollection}
+   */
+  inserJeunesNationals: () => dbCollection("inserJeunesNationals"),
+  /**
+   * @typedef {import("mongodb").Collection<import("./formationsStats").FormationsStats>} FormationsStatsCollection
+   * @returns {FormationsStatsCollection}
+   */
+  formationsStats: () => dbCollection("formationsStats"),
 };

--- a/server/src/common/collections/schemas.js
+++ b/server/src/common/collections/schemas.js
@@ -1,0 +1,5 @@
+module.exports = {
+  logs: require("./logs"),
+  inserJeunesNationals: require("./inserJeunesNationals"),
+  formationsStats: require("./formationsStats"),
+};

--- a/server/src/common/mongodb.js
+++ b/server/src/common/mongodb.js
@@ -1,6 +1,6 @@
 const { MongoClient } = require("mongodb");
 const config = require("../config");
-const collections = require("./collections");
+const collections = require("./collections/schemas");
 const logger = require("./logger").child({ context: "db" });
 const { writeData } = require("oleoduc");
 

--- a/server/src/http/routes/svgRoutes.js
+++ b/server/src/http/routes/svgRoutes.js
@@ -5,10 +5,10 @@ const tryCatch = require("../middlewares/tryCatchMiddleware");
 const ejs = require("ejs");
 const path = require("path");
 const Joi = require("joi");
-const { dbCollection } = require("../../common/mongodb");
 const { validate } = require("../utils/validators");
 const { getRateLevel } = require("../../common/rateLevels");
 const { formatMillesime } = require("../utils/formatters");
+const { formationsStats, inserJeunesNationals } = require("../../common/collections");
 
 /**
  * @typedef {{taux_emploi_6_mois?: number, taux_poursuite_etudes?: number, filiere?:"apprentissage" | "pro", diplome?:string}} InserJeunesData
@@ -115,10 +115,7 @@ module.exports = () => {
 
       const { direction = "vertical", theme = "dsfr" } = query;
 
-      /**
-       * @type {import("../../common/collections/formationsStats").FormationsStats}
-       */
-      const stats = await dbCollection("formationsStats").findOne(
+      const stats = await formationsStats().findOne(
         {
           uai,
           code_formation,
@@ -162,10 +159,7 @@ module.exports = () => {
 
       const { direction = "vertical", theme = "dsfr" } = query;
 
-      /**
-       * @type {import("../../common/collections/inserJeunesNationals").InserJeunesNationals}
-       */
-      const inserJeunesData = await dbCollection("inserJeunesNationals").findOne(
+      const inserJeunesData = await inserJeunesNationals().findOne(
         {
           code_formation,
           millesime: formatMillesime(millesime),

--- a/server/src/types/generateTypes.js
+++ b/server/src/types/generateTypes.js
@@ -1,7 +1,7 @@
 const fs = require("fs");
 const path = require("path");
 const { compile } = require("json-schema-to-typescript");
-const collections = require("../common/collections/index");
+const collections = require("../common/collections/schemas");
 const packageJson = require("../../package.json");
 
 const disableAdditionalProperties = (node) => {


### PR DESCRIPTION
```ts
const { formationsStats } = require("../../common/collections");
...

const stats = await formationsStats().findOne(...);
// --> has the TypeScript type FormationsStats
```