### PR TITLE
Feature/multiple filieres widget

### DIFF
--- a/server/src/common/certifications.js
+++ b/server/src/common/certifications.js
@@ -18,6 +18,8 @@ const aggregateStats = (stats) => {
   const aggregatedStats = stats.reduce((acc, curr) => {
     acc["codes_certifications"] = [...(acc["codes_certifications"] ?? []), curr.code_certification];
     acc["millesime"] = curr.millesime;
+    acc["filiere"] = curr.filiere;
+    acc["diplome"] = curr.diplome;
     acc["nb_annee_term"] = (acc["nb_annee_term"] ?? 0) + (curr.nb_annee_term ?? 0);
     acc["nb_en_emploi_12_mois"] = (acc["nb_en_emploi_12_mois"] ?? 0) + (curr.nb_en_emploi_12_mois ?? 0);
     acc["nb_en_emploi_6_mois"] = (acc["nb_en_emploi_6_mois"] ?? 0) + (curr.nb_en_emploi_6_mois ?? 0);

--- a/server/src/http/routes/certificationsRoutes.js
+++ b/server/src/http/routes/certificationsRoutes.js
@@ -97,7 +97,7 @@ export default () => {
   };
 
   const handleMultipleCertifications = async (res, params) => {
-    const { codes_certifications, millesime } = params;
+    const { codes_certifications, millesime, direction, theme, ext } = params;
 
     const results = await certificationsStats()
       .find(
@@ -112,7 +112,15 @@ export default () => {
     }
 
     const mergedStats = aggregateCertificationsStatsByFiliere(results);
-    return res.json(mergedStats);
+    if (ext !== "svg") {
+      return res.json(mergedStats);
+    }
+
+    if (Object.keys(mergedStats).length === 1) {
+      return sendWidget("certification", Object.values(mergedStats)[0], res, { theme, direction });
+    }
+
+    return sendWidget("filieres", mergedStats, res, { theme, direction });
   };
 
   router.get(

--- a/server/src/http/templates/dsfr/filieres-horizontal.svg.ejs
+++ b/server/src/http/templates/dsfr/filieres-horizontal.svg.ejs
@@ -1,0 +1,214 @@
+<% const height = 290 %> <% const width = 700 %> <% const rightOffset = 350 %>
+
+<svg
+  width="<%= width %>"
+  height="<%= height %>"
+  viewBox="0 0 <%= width %> <%= height %>"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <rect x="0.5" y="0.5" width="<%= width - 1 %>" height="<%= height - 1 %>" fill="white" />
+  <rect x="0.5" y="0.5" width="<%= width - 1 %>" height="<%= height - 1 %>" stroke="#E5E5E5" />
+  <rect width="<%= width %>" height="86" fill="#F5F5FE" />
+  <text
+    fill="#3A3A3A"
+    xml:space="preserve"
+    style="white-space: pre"
+    font-family="Marianne"
+    font-size="20"
+    font-weight="bold"
+    letter-spacing="0em"
+  >
+    <tspan x="30" y="52.625">Que deviennent les apprenants apr&#xe8;s cette formation ?</tspan>
+  </text>
+
+  <text
+    fill="#000091"
+    xml:space="preserve"
+    style="white-space: pre"
+    font-family="Marianne"
+    font-size="18"
+    letter-spacing="0em"
+  >
+    <tspan x="23" y="127.875">Sont en emploi 6 mois après la</tspan>
+    <tspan x="23" y="147.875">fin de la formation</tspan>
+  </text>
+
+  <g class="<%= rates.apprentissage[0].level %>">
+    <rect x="23" y="165" width="90" height="35" rx="4" class="bg" />
+
+    <g transform="translate(31,175)"><%- await include(`../assets/${rates.apprentissage[0].level}-icon.svg.ejs`); %></g>
+
+    <text
+      class="label"
+      xml:space="preserve"
+      style="white-space: pre"
+      font-family="Marianne"
+      font-size="25"
+      font-weight="bold"
+      letter-spacing="0em"
+    >
+      <tspan x="50.5" y="193.438"><%= rates.apprentissage[0].rate %>%</tspan>
+    </text>
+
+    <text
+      fill="#3A3A3A"
+      xml:space="preserve"
+      style="white-space: pre"
+      font-family="Marianne"
+      font-size="14"
+      letter-spacing="0em"
+    >
+      <tspan x="23" y="218.125">Apprentissage</tspan>
+    </text>
+  </g>
+
+  <g class="<%= rates.pro[0].level %>">
+    <rect x="182" y="165" width="90" height="35" rx="4" class="bg" />
+
+    <g transform="translate(190,175)"><%- await include(`../assets/${rates.pro[0].level}-icon.svg.ejs`); %></g>
+
+    <text
+      class="label"
+      xml:space="preserve"
+      style="white-space: pre"
+      font-family="Marianne"
+      font-size="25"
+      font-weight="bold"
+      letter-spacing="0em"
+    >
+      <tspan x="209.5" y="193.438"><%= rates.pro[0].rate %>%</tspan>
+    </text>
+    <text
+      fill="#3A3A3A"
+      xml:space="preserve"
+      style="white-space: pre"
+      font-family="Marianne"
+      font-size="14"
+      letter-spacing="0em"
+    >
+      <tspan x="182" y="218.125">Voie scolaire</tspan>
+    </text>
+  </g>
+
+  <line x1="350" y1="107.875" x2="350" y2="228.125" stroke="#E5E5E5" />
+
+  <text
+    fill="#000091"
+    xml:space="preserve"
+    style="white-space: pre"
+    font-family="Marianne"
+    font-size="18"
+    letter-spacing="0em"
+  >
+    <tspan x="<%= 23 + rightOffset %>" y="127.875">Poursuivent leurs &#xe9;tudes</tspan>
+  </text>
+
+  <g class="<%= rates.apprentissage[1].level %>">
+    <rect x="<%= 23 + rightOffset %>" y="165" width="90" height="35" rx="4" class="bg" />
+
+    <g transform="translate(<%= 31 + rightOffset %>,175)">
+      <%- await include(`../assets/${rates.apprentissage[1].level}-icon.svg.ejs`); %>
+    </g>
+
+    <text
+      class="label"
+      xml:space="preserve"
+      style="white-space: pre"
+      font-family="Marianne"
+      font-size="25"
+      font-weight="bold"
+      letter-spacing="0em"
+    >
+      <tspan x="<%= 50.5 + rightOffset %>" y="193.438"><%= rates.apprentissage[1].rate %>%</tspan>
+    </text>
+    <text
+      fill="#3A3A3A"
+      xml:space="preserve"
+      style="white-space: pre"
+      font-family="Marianne"
+      font-size="14"
+      letter-spacing="0em"
+    >
+      <tspan x="<%= 23 + rightOffset %>" y="218.125">Apprentissage</tspan>
+    </text>
+  </g>
+
+  <g class="<%= rates.pro[1].level %>">
+    <rect x="<%= 182 + rightOffset %>" y="165" width="90" height="35" rx="4" class="bg" />
+
+    <g transform="translate(<%= 190 + rightOffset %>,175)">
+      <%- await include(`../assets/${rates.pro[1].level}-icon.svg.ejs`); %>
+    </g>
+
+    <text
+      class="label"
+      xml:space="preserve"
+      style="white-space: pre"
+      font-family="Marianne"
+      font-size="25"
+      font-weight="bold"
+      letter-spacing="0em"
+    >
+      <tspan x="<%= 209.5 + rightOffset %>" y="193.438"><%= rates.pro[1].rate %>%</tspan>
+    </text>
+    <text
+      fill="#3A3A3A"
+      xml:space="preserve"
+      style="white-space: pre"
+      font-family="Marianne"
+      font-size="14"
+      letter-spacing="0em"
+    >
+      <tspan x="<%= 182 + rightOffset %>" y="218.125">Voie scolaire</tspan>
+    </text>
+  </g>
+
+  <text
+    fill="#3A3A3A"
+    xml:space="preserve"
+    style="white-space: pre"
+    font-family="Marianne"
+    font-size="11"
+    font-style="italic"
+    letter-spacing="0em"
+  >
+    <tspan x="23" y="<%= height - 34 %>">Chiffres issus du site InserJeunes</tspan>
+  </text>
+
+  <defs>
+    <style type="text/css">
+      @font-face {
+        font-family: "Marianne";
+        src: url("data:font/truetype;charset=utf-8;base64,<%= base64Font %>") format("woff");
+        font-weight: 500;
+        font-style: normal;
+        font-display: swap;
+      }
+      .success .bg {
+        fill: #b8fec9;
+      }
+      .success .label {
+        fill: #18753c;
+      }
+      .info .bg {
+        fill: #e8edff;
+      }
+      .info .label {
+        fill: #0063cb;
+      }
+      .danger .bg {
+        fill: #ffe9e9;
+      }
+      .danger .label {
+        fill: #ce0500;
+      }
+      .warning .bg {
+        fill: #feecc2;
+      }
+      .warning .label {
+        fill: #716043;
+      }
+    </style>
+  </defs>
+</svg>

--- a/server/src/http/templates/dsfr/filieres-vertical.svg.ejs
+++ b/server/src/http/templates/dsfr/filieres-vertical.svg.ejs
@@ -1,0 +1,206 @@
+<% const height = 433 %>
+
+<svg width="320" height="<%= height %>" viewBox="0 0 320 <%= height %>" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0.5" y="0.5" width="319" height="<%= height - 1 %>" fill="white" />
+  <rect x="0.5" y="0.5" width="319" height="<%= height - 1 %>" stroke="#E5E5E5" />
+  <rect width="320" height="105" fill="#F5F5FE" />
+  <text
+    fill="#3A3A3A"
+    xml:space="preserve"
+    style="white-space: pre"
+    font-family="Marianne"
+    font-size="20"
+    font-weight="bold"
+    letter-spacing="0em"
+  >
+    <tspan x="23" y="37.75">Que deviennent les</tspan>
+    <tspan x="23" y="61.75">apprenants apr&#xe8;s cette</tspan>
+    <tspan x="23" y="85.75">formation ?</tspan>
+  </text>
+
+  <text
+    fill="#000091"
+    xml:space="preserve"
+    style="white-space: pre"
+    font-family="Marianne"
+    font-size="18"
+    letter-spacing="0em"
+  >
+    <tspan x="23" y="147.875">Sont en emploi 6 mois après la</tspan>
+    <tspan x="23" y="167.875">fin de la formation</tspan>
+  </text>
+
+  <g class="<%= rates.apprentissage[0].level %>">
+    <rect x="23" y="185" width="90" height="35" rx="4" class="bg" />
+
+    <g transform="translate(31,195)"><%- await include(`../assets/${rates.apprentissage[0].level}-icon.svg.ejs`); %></g>
+
+    <text
+      class="label"
+      xml:space="preserve"
+      style="white-space: pre"
+      font-family="Marianne"
+      font-size="25"
+      font-weight="bold"
+      letter-spacing="0em"
+    >
+      <tspan x="50.5" y="213.438"><%= rates.apprentissage[0].rate %>%</tspan>
+    </text>
+
+    <text
+      fill="#3A3A3A"
+      xml:space="preserve"
+      style="white-space: pre"
+      font-family="Marianne"
+      font-size="14"
+      letter-spacing="0em"
+    >
+      <tspan x="23" y="238.125">Apprentissage</tspan>
+    </text>
+  </g>
+
+  <g class="<%= rates.pro[0].level %>">
+    <rect x="182" y="185" width="90" height="35" rx="4" class="bg" />
+
+    <g transform="translate(190,195)"><%- await include(`../assets/${rates.pro[0].level}-icon.svg.ejs`); %></g>
+
+    <text
+      class="label"
+      xml:space="preserve"
+      style="white-space: pre"
+      font-family="Marianne"
+      font-size="25"
+      font-weight="bold"
+      letter-spacing="0em"
+    >
+      <tspan x="209.5" y="213.438"><%= rates.pro[0].rate %>%</tspan>
+    </text>
+    <text
+      fill="#3A3A3A"
+      xml:space="preserve"
+      style="white-space: pre"
+      font-family="Marianne"
+      font-size="14"
+      letter-spacing="0em"
+    >
+      <tspan x="182" y="238.125">Voie scolaire</tspan>
+    </text>
+  </g>
+
+  <line x1="22" y1="258.5" x2="282" y2="258.5" stroke="#E5E5E5" />
+
+  <text
+    fill="#000091"
+    xml:space="preserve"
+    style="white-space: pre"
+    font-family="Marianne"
+    font-size="18"
+    letter-spacing="0em"
+  >
+    <tspan x="23" y="290.875">Poursuivent leurs &#xe9;tudes</tspan>
+  </text>
+
+  <g class="<%= rates.apprentissage[1].level %>">
+    <rect x="23" y="308" width="90" height="35" rx="4" class="bg" />
+
+    <g transform="translate(31,318)"><%- await include(`../assets/${rates.apprentissage[1].level}-icon.svg.ejs`); %></g>
+
+    <text
+      class="label"
+      xml:space="preserve"
+      style="white-space: pre"
+      font-family="Marianne"
+      font-size="25"
+      font-weight="bold"
+      letter-spacing="0em"
+    >
+      <tspan x="50.5" y="336.438"><%= rates.apprentissage[1].rate %>%</tspan>
+    </text>
+    <text
+      fill="#3A3A3A"
+      xml:space="preserve"
+      style="white-space: pre"
+      font-family="Marianne"
+      font-size="14"
+      letter-spacing="0em"
+    >
+      <tspan x="23" y="362.125">Apprentissage</tspan>
+    </text>
+  </g>
+
+  <g class="<%= rates.pro[1].level %>">
+    <rect x="182" y="308" width="90" height="35" rx="4" class="bg" />
+
+    <g transform="translate(190,318)"><%- await include(`../assets/${rates.pro[1].level}-icon.svg.ejs`); %></g>
+
+    <text
+      class="label"
+      xml:space="preserve"
+      style="white-space: pre"
+      font-family="Marianne"
+      font-size="25"
+      font-weight="bold"
+      letter-spacing="0em"
+    >
+      <tspan x="209.5" y="336.438"><%= rates.pro[1].rate %>%</tspan>
+    </text>
+    <text
+      fill="#3A3A3A"
+      xml:space="preserve"
+      style="white-space: pre"
+      font-family="Marianne"
+      font-size="14"
+      letter-spacing="0em"
+    >
+      <tspan x="182" y="362.125">Voie scolaire</tspan>
+    </text>
+  </g>
+
+  <text
+    fill="#3A3A3A"
+    xml:space="preserve"
+    style="white-space: pre"
+    font-family="Marianne"
+    font-size="11"
+    font-style="italic"
+    letter-spacing="0em"
+  >
+    <tspan x="23" y="<%= height - 34 %>">Chiffres issus du site InserJeunes</tspan>
+  </text>
+
+  <defs>
+    <style type="text/css">
+      @font-face {
+        font-family: "Marianne";
+        src: url("data:font/truetype;charset=utf-8;base64,<%= base64Font %>") format("woff");
+        font-weight: 500;
+        font-style: normal;
+        font-display: swap;
+      }
+      .success .bg {
+        fill: #b8fec9;
+      }
+      .success .label {
+        fill: #18753c;
+      }
+      .info .bg {
+        fill: #e8edff;
+      }
+      .info .label {
+        fill: #0063cb;
+      }
+      .danger .bg {
+        fill: #ffe9e9;
+      }
+      .danger .label {
+        fill: #ce0500;
+      }
+      .warning .bg {
+        fill: #feecc2;
+      }
+      .warning .label {
+        fill: #716043;
+      }
+    </style>
+  </defs>
+</svg>

--- a/server/src/http/templates/onisep/filieres-horizontal.svg.ejs
+++ b/server/src/http/templates/onisep/filieres-horizontal.svg.ejs
@@ -1,0 +1,178 @@
+<% const height = 270 %> <% const width = 700 %> <% const rightOffset = 350 %>
+
+<svg
+  width="<%= width %>"
+  height="<%= height %>"
+  viewBox="0 0 <%= width %> <%= height %>"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <rect
+    x="2"
+    y="2"
+    width="<%= width - 4 %>"
+    height="<%= height - 4 %>"
+    fill="white"
+    stroke="#FFD400"
+    stroke-width="4"
+  />
+
+  <text
+    fill="black"
+    xml:space="preserve"
+    style="white-space: pre"
+    font-family="Expressway Free"
+    font-size="22"
+    font-weight="bold"
+    letter-spacing="0em"
+  >
+    <tspan x="23" y="52.625">Que deviennent les apprenants apr&#xe8;s cette formation ?</tspan>
+  </text>
+
+  <text
+    fill="black"
+    xml:space="preserve"
+    style="white-space: pre"
+    font-family="Expressway Free"
+    font-size="20"
+    letter-spacing="0em"
+  >
+    <tspan x="23" y="107.875">Sont en emploi 6 mois après la</tspan>
+    <tspan x="23" y="127.875">fin de la formation</tspan>
+  </text>
+
+  <g>
+    <rect x="23" y="145" width="90" height="35" rx="4" fill="#0D7B92" />
+
+    <text
+      fill="white"
+      xml:space="preserve"
+      style="white-space: pre"
+      font-family="Expressway Free"
+      font-size="27"
+      font-weight="bold"
+      letter-spacing="0em"
+    >
+      <tspan x="50.5" y="173.438"><%= rates.apprentissage[0].rate %>%</tspan>
+    </text>
+
+    <text
+      fill="black"
+      xml:space="preserve"
+      style="white-space: pre"
+      font-family="Expressway Free"
+      font-size="16"
+      letter-spacing="0em"
+    >
+      <tspan x="23" y="198.125">Apprentissage</tspan>
+    </text>
+  </g>
+
+  <g>
+    <rect x="182" y="145" width="90" height="35" rx="4" fill="#0D7B92" />
+    <text
+      fill="white"
+      xml:space="preserve"
+      style="white-space: pre"
+      font-family="Expressway Free"
+      font-size="27"
+      font-weight="bold"
+      letter-spacing="0em"
+    >
+      <tspan x="209.5" y="173.438"><%= rates.pro[0].rate %>%</tspan>
+    </text>
+    <text
+      fill="black"
+      xml:space="preserve"
+      style="white-space: pre"
+      font-family="Expressway Free"
+      font-size="16"
+      letter-spacing="0em"
+    >
+      <tspan x="182" y="198.125">Voie scolaire</tspan>
+    </text>
+  </g>
+
+  <line x1="350" y1="87.875" x2="350" y2="208.125" stroke="#E5E5E5" />
+
+  <text
+    fill="black"
+    xml:space="preserve"
+    style="white-space: pre"
+    font-family="Expressway Free"
+    font-size="20"
+    letter-spacing="0em"
+  >
+    <tspan x="<%= 23 + rightOffset %>" y="107.875">Poursuivent leurs &#xe9;tudes</tspan>
+  </text>
+
+  <g>
+    <rect x="<%= 23 + rightOffset %>" y="145" width="90" height="35" rx="4" fill="#0D7B92" />
+
+    <text
+      fill="white"
+      xml:space="preserve"
+      style="white-space: pre"
+      font-family="Expressway Free"
+      font-size="27"
+      font-weight="bold"
+      letter-spacing="0em"
+    >
+      <tspan x="<%= 50.5 + rightOffset %>" y="173.438"><%= rates.apprentissage[1].rate %>%</tspan>
+    </text>
+    <text
+      fill="black"
+      xml:space="preserve"
+      style="white-space: pre"
+      font-family="Expressway Free"
+      font-size="16"
+      letter-spacing="0em"
+    >
+      <tspan x="<%= 23 + rightOffset %>" y="198.125">Apprentissage</tspan>
+    </text>
+  </g>
+
+  <g>
+    <rect x="<%= 182 + rightOffset %>" y="145" width="90" height="35" rx="4" fill="#0D7B92" />
+
+    <text
+      fill="white"
+      xml:space="preserve"
+      style="white-space: pre"
+      font-family="Expressway Free"
+      font-size="27"
+      font-weight="bold"
+      letter-spacing="0em"
+    >
+      <tspan x="<%= 209.5 + rightOffset %>" y="173.438"><%= rates.pro[1].rate %>%</tspan>
+    </text>
+    <text
+      fill="black"
+      xml:space="preserve"
+      style="white-space: pre"
+      font-family="Expressway Free"
+      font-size="16"
+      letter-spacing="0em"
+    >
+      <tspan x="<%= 182 + rightOffset %>" y="198.125">Voie scolaire</tspan>
+    </text>
+  </g>
+
+  <text
+    fill="#3A3A3A"
+    xml:space="preserve"
+    style="white-space: pre"
+    font-family="Expressway Free"
+    font-size="13"
+    font-style="italic"
+    letter-spacing="0em"
+  >
+    <tspan x="23" y="<%= height - 34 %>">Chiffres issus du site InserJeunes</tspan>
+  </text>
+
+  <defs>
+    <style>
+      @import url("https://fonts.cdnfonts.com/css/expressway-free");
+    </style>
+  </defs>
+</svg>

--- a/server/src/http/templates/onisep/filieres-vertical.svg.ejs
+++ b/server/src/http/templates/onisep/filieres-vertical.svg.ejs
@@ -1,0 +1,181 @@
+<% const height = 413 %> <% const width = 320 %>
+
+<svg
+  width="<%= width %>"
+  height="<%= height %>"
+  viewBox="0 0 <%= width %> <%= height %>"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <rect
+    x="2"
+    y="2"
+    width="<%= width - 4 %>"
+    height="<%= height - 4 %>"
+    fill="white"
+    stroke="#FFD400"
+    stroke-width="4"
+  />
+
+  <text
+    fill="black"
+    xml:space="preserve"
+    style="white-space: pre"
+    font-family="Expressway Free"
+    font-size="22"
+    font-weight="bold"
+    letter-spacing="0em"
+  >
+    <tspan x="23" y="37.75">Que deviennent les</tspan>
+    <tspan x="23" y="61.75">apprenants apr&#xe8;s cette</tspan>
+    <tspan x="23" y="85.75">formation ?</tspan>
+  </text>
+
+  <text
+    fill="black"
+    xml:space="preserve"
+    style="white-space: pre"
+    font-family="Expressway Free"
+    font-size="20"
+    letter-spacing="0em"
+  >
+    <tspan x="23" y="127.875">Sont en emploi 6 mois après la</tspan>
+    <tspan x="23" y="147.875">fin de la formation</tspan>
+  </text>
+
+  <g>
+    <rect x="23" y="165" width="90" height="35" rx="4" fill="#0D7B92" />
+
+    <text
+      fill="white"
+      xml:space="preserve"
+      style="white-space: pre"
+      font-family="Expressway Free"
+      font-size="27"
+      font-weight="bold"
+      letter-spacing="0em"
+    >
+      <tspan x="50.5" y="193.438"><%= rates.apprentissage[0].rate %>%</tspan>
+    </text>
+
+    <text
+      fill="black"
+      xml:space="preserve"
+      style="white-space: pre"
+      font-family="Expressway Free"
+      font-size="16"
+      letter-spacing="0em"
+    >
+      <tspan x="23" y="218.125">Apprentissage</tspan>
+    </text>
+  </g>
+
+  <g>
+    <rect x="182" y="165" width="90" height="35" rx="4" fill="#0D7B92" />
+
+    <text
+      fill="white"
+      xml:space="preserve"
+      style="white-space: pre"
+      font-family="Expressway Free"
+      font-size="27"
+      font-weight="bold"
+      letter-spacing="0em"
+    >
+      <tspan x="209.5" y="193.438"><%= rates.pro[0].rate %>%</tspan>
+    </text>
+    <text
+      fill="black"
+      xml:space="preserve"
+      style="white-space: pre"
+      font-family="Expressway Free"
+      font-size="16"
+      letter-spacing="0em"
+    >
+      <tspan x="182" y="218.125">Voie scolaire</tspan>
+    </text>
+  </g>
+
+  <line x1="22" y1="238.5" x2="282" y2="238.5" stroke="#E5E5E5" />
+
+  <text
+    fill="black"
+    xml:space="preserve"
+    style="white-space: pre"
+    font-family="Expressway Free"
+    font-size="20"
+    letter-spacing="0em"
+  >
+    <tspan x="23" y="270.875">Poursuivent leurs &#xe9;tudes</tspan>
+  </text>
+
+  <g>
+    <rect x="23" y="288" width="90" height="35" rx="4" fill="#0D7B92" />
+
+    <text
+      fill="white"
+      xml:space="preserve"
+      style="white-space: pre"
+      font-family="Expressway Free"
+      font-size="27"
+      font-weight="bold"
+      letter-spacing="0em"
+    >
+      <tspan x="50.5" y="316.438"><%= rates.apprentissage[1].rate %>%</tspan>
+    </text>
+    <text
+      fill="black"
+      xml:space="preserve"
+      style="white-space: pre"
+      font-family="Expressway Free"
+      font-size="16"
+      letter-spacing="0em"
+    >
+      <tspan x="23" y="342.125">Apprentissage</tspan>
+    </text>
+  </g>
+
+  <g>
+    <rect x="182" y="288" width="90" height="35" rx="4" fill="#0D7B92" />
+
+    <text
+      fill="white"
+      xml:space="preserve"
+      style="white-space: pre"
+      font-family="Expressway Free"
+      font-size="27"
+      font-weight="bold"
+      letter-spacing="0em"
+    >
+      <tspan x="209.5" y="316.438"><%= rates.pro[1].rate %>%</tspan>
+    </text>
+    <text
+      fill="black"
+      xml:space="preserve"
+      style="white-space: pre"
+      font-family="Expressway Free"
+      font-size="16"
+      letter-spacing="0em"
+    >
+      <tspan x="182" y="342.125">Voie scolaire</tspan>
+    </text>
+  </g>
+
+  <text
+    fill="#3A3A3A"
+    xml:space="preserve"
+    style="white-space: pre"
+    font-family="Expressway Free"
+    font-size="13"
+    font-style="italic"
+    letter-spacing="0em"
+  >
+    <tspan x="23" y="<%= height - 34 %>">Chiffres issus du site InserJeunes</tspan>
+  </text>
+
+  <defs>
+    <style>
+      @import url("https://fonts.cdnfonts.com/css/expressway-free");
+    </style>
+  </defs>
+</svg>

--- a/server/src/http/utils/widget.js
+++ b/server/src/http/utils/widget.js
@@ -35,6 +35,11 @@ const TEMPLATES = {
       vertical: path.join(__dirname, `../templates/onisep/certification-vertical.svg.ejs`),
       horizontal: path.join(__dirname, `../templates/onisep/certification-horizontal.svg.ejs`),
     },
+    // national + filieres apprentissage & pro
+    filieres: {
+      vertical: path.join(__dirname, `../templates/onisep/filieres-vertical.svg.ejs`),
+      horizontal: path.join(__dirname, `../templates/onisep/filieres-horizontal.svg.ejs`),
+    },
   },
 };
 

--- a/server/src/http/utils/widget.js
+++ b/server/src/http/utils/widget.js
@@ -18,6 +18,11 @@ const TEMPLATES = {
       vertical: path.join(__dirname, `../templates/dsfr/certification-vertical.svg.ejs`),
       horizontal: path.join(__dirname, `../templates/dsfr/certification-horizontal.svg.ejs`),
     },
+    // national + filieres apprentissage & pro
+    filieres: {
+      vertical: path.join(__dirname, `../templates/dsfr/filieres-vertical.svg.ejs`),
+      horizontal: path.join(__dirname, `../templates/dsfr/filieres-horizontal.svg.ejs`),
+    },
   },
   onisep: {
     // local : action de formation (formation donnée dans un établissement donné)
@@ -70,9 +75,17 @@ function renderTemplate(type, rates, options) {
 }
 
 export async function sendWidget(type, stats, res, options) {
-  const rates = getRates(stats);
-  if (rates.length === 0) {
-    return res.status(404).send("Données statistiques non disponibles");
+  let rates = [];
+  if (type === "filieres") {
+    rates = { pro: getRates(stats.pro), apprentissage: getRates(stats.apprentissage) };
+    if (rates.pro.length === 0 && rates.apprentissage.length === 0) {
+      return res.status(404).send("Données statistiques non disponibles");
+    }
+  } else {
+    rates = getRates(stats);
+    if (rates.length === 0) {
+      return res.status(404).send("Données statistiques non disponibles");
+    }
   }
 
   const svg = await renderTemplate(type, rates, options);

--- a/server/tests/common/certifications-test.js
+++ b/server/tests/common/certifications-test.js
@@ -64,6 +64,11 @@ describe("aggregateCertificationsStatsByFiliere", () => {
     assert.deepStrictEqual(aggregateCertificationsStatsByFiliere(certifications), {
       apprentissage: {
         codes_certifications: ["3301144", "3301145"],
+        diplome: {
+          code: "5",
+          libelle: "BTS",
+        },
+        filiere: "apprentissage",
         millesime: "2020",
         nb_annee_term: 3200,
         nb_en_emploi_12_mois: 1000,
@@ -152,6 +157,11 @@ describe("aggregateCertificationsStatsByFiliere", () => {
     assert.deepStrictEqual(aggregateCertificationsStatsByFiliere(certifications), {
       apprentissage: {
         codes_certifications: ["3301144", "3301145"],
+        diplome: {
+          code: "5",
+          libelle: "BTS",
+        },
+        filiere: "apprentissage",
         millesime: "2020",
         nb_annee_term: 3200,
         nb_en_emploi_12_mois: 1000,
@@ -164,6 +174,11 @@ describe("aggregateCertificationsStatsByFiliere", () => {
       },
       pro: {
         codes_certifications: ["3301146", "3301147"],
+        diplome: {
+          code: "5",
+          libelle: "BTS",
+        },
+        filiere: "pro",
         millesime: "2020",
         nb_annee_term: 5000,
         nb_en_emploi_12_mois: 520,

--- a/server/tests/http/certificationsRoutes-test.js
+++ b/server/tests/http/certificationsRoutes-test.js
@@ -314,5 +314,42 @@ describe("certificationsRoutes", () => {
 
       assert.strictEqual(response.status, 400);
     });
+
+    it("Vérifie qu'on peut obtient une image avec les deux filières", async () => {
+      const { httpClient } = await startServer();
+      await insertCertificationsStats({
+        code_certification: "23830024203",
+        filiere: "apprentissage",
+        taux_poursuite_etudes: 5,
+        taux_emploi_6_mois: 50,
+        millesime: "2020",
+        nb_annee_term: 100,
+        nb_poursuite_etudes: 5,
+        nb_en_emploi_6_mois: 25,
+        nb_sortant: 50,
+      });
+      await insertCertificationsStats({
+        code_certification: "23830024202",
+        filiere: "pro",
+        taux_poursuite_etudes: 10,
+        taux_emploi_6_mois: 25,
+        millesime: "2020",
+        nb_annee_term: 100,
+        nb_poursuite_etudes: 10,
+        nb_en_emploi_6_mois: 15,
+        nb_sortant: 60,
+      });
+
+      const response = await httpClient.get("/api/inserjeunes/certifications/23830024203|23830024202.svg");
+
+      assert.strictEqual(response.status, 200);
+      assert.ok(response.headers["content-type"].includes("image/svg+xml"));
+      assert.ok(response.data.includes("5%"));
+      assert.ok(response.data.includes("50%"));
+      assert.ok(response.data.includes("10%"));
+      assert.ok(response.data.includes("25%"));
+      assert.ok(response.data.includes("Apprentissage"));
+      assert.ok(response.data.includes("Voie scolaire"));
+    });
   });
 });


### PR DESCRIPTION
Widgets with multiple certifications call,
e.g : `api/inserjeunes/certifications/32221031409|32221033001|23110022133|01033410|44633521.svg`

![dsfr-h](https://user-images.githubusercontent.com/809411/174095256-a390307f-ff40-4e4d-bee7-6f8e1016e95d.png)
![dsfr-v](https://user-images.githubusercontent.com/809411/174095263-693ac907-0e04-4ab5-b4f4-dcc028ac1de7.png)
![onisep-h](https://user-images.githubusercontent.com/809411/174095296-60cbef1a-192f-4f28-ac1f-f0aa5acba3fb.png)
![onisep-v](https://user-images.githubusercontent.com/809411/174095292-8571c0fc-f9e5-4be5-a80e-75979e2bfa6d.png)
