### PR TITLE
MEP : Nouveau millésime et correction d'erreurs

### DIFF
--- a/reverse_proxy/app/nginx/templates/conf.d/limit_req.conf.template
+++ b/reverse_proxy/app/nginx/templates/conf.d/limit_req.conf.template
@@ -1,4 +1,4 @@
 # Maximum 2400r/m pour l'ensemble des utilisateurs avant dégradation du service
-limit_req_zone $binary_remote_addr zone=flood:10m rate=400r/m;
+limit_req_zone $binary_remote_addr zone=flood:10m rate=800r/m;
 limit_req_log_level error;
 limit_req zone=flood burst=100 nodelay;

--- a/server/.eslintrc
+++ b/server/.eslintrc
@@ -1,13 +1,7 @@
 {
   "root": true,
-  "extends": [
-    "eslint:recommended",
-    "plugin:node/recommended",
-    "plugin:prettier/recommended"
-  ],
-  "plugins": [
-    "mocha"
-  ],
+  "extends": ["eslint:recommended", "plugin:node/recommended-module", "plugin:prettier/recommended"],
+  "plugins": ["mocha"],
   "env": {
     "node": true,
     "es6": true,

--- a/server/.eslintrc
+++ b/server/.eslintrc
@@ -18,7 +18,8 @@
     {
       "files": "tests/**/*.js",
       "rules": {
-        "node/no-unpublished-require": 0
+        "node/no-unpublished-require": 0,
+        "node/no-unpublished-import": 0
       }
     }
   ]

--- a/server/package.json
+++ b/server/package.json
@@ -49,7 +49,7 @@
     "yamljs": "0.3.0"
   },
   "engines": {
-    "node": ">=12.11.0"
+    "node": ">=16.14.0"
   },
   "prettier": {
     "printWidth": 120,
@@ -59,6 +59,7 @@
   "devDependencies": {
     "@faker-js/faker": "6.3.1",
     "axiosist": "0.10.0",
+    "chai": "4.3.7",
     "chalk": "4.1.2",
     "eslint": "7.1.0",
     "eslint-config-prettier": "6.11.0",

--- a/server/package.json
+++ b/server/package.json
@@ -61,7 +61,7 @@
     "chalk": "4.1.2",
     "eslint": "7.1.0",
     "eslint-config-prettier": "6.11.0",
-    "eslint-plugin-mocha": "10.0.4",
+    "eslint-plugin-mocha": "10.1.0",
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-prettier": "3.1.3",
     "lint-staged": ">=10",

--- a/server/package.json
+++ b/server/package.json
@@ -17,6 +17,7 @@
     "lint": "eslint src/ tests/"
   },
   "dependencies": {
+    "async-retry": "1.3.3",
     "axios": "0.27.2",
     "body-parser": "1.20.0",
     "boom": "7.3.0",
@@ -67,7 +68,7 @@
     "lint-staged": ">=10",
     "mocha": "10.0.0",
     "mongodb-memory-server": "8.5.2",
-    "nock": "13.2.4",
+    "nock": "13.3.0",
     "nodemon": "2.0.16",
     "nyc": "15.1.0",
     "prettier": "2.6.2"

--- a/server/src/common/db/mongodb.js
+++ b/server/src/common/db/mongodb.js
@@ -11,11 +11,11 @@ function ensureInitialization() {
   }
 }
 
-function sendLogsToMongodb() {
+export function sendLogsToMongodb(logger, level = "info") {
   logger.addStream({
     name: "mongodb",
     type: "raw",
-    level: "info",
+    level: level,
     stream: writeData((data) => dbCollection("logs").insertOne(data)),
   });
 }
@@ -30,7 +30,7 @@ export async function connectToMongodb(uri = config.mongodb.uri) {
   clientHolder = client;
 
   if (config.log.destinations.includes("mongodb")) {
-    sendLogsToMongodb();
+    sendLogsToMongodb(logger);
   }
 
   return client;

--- a/server/src/common/inserjeunes/InserJeunes.js
+++ b/server/src/common/inserjeunes/InserJeunes.js
@@ -1,5 +1,5 @@
 import { Readable } from "stream";
-import { filterData, accumulateData, flattenArray, oleoduc, writeData } from "oleoduc";
+import { transformData, filterData, accumulateData, flattenArray, oleoduc, writeData } from "oleoduc";
 
 import { InserJeunesApi } from "./InserJeunesApi.js";
 import { streamNestedJsonArray } from "../utils/streamUtils.js";
@@ -18,7 +18,7 @@ function filterFormationStats() {
   });
 }
 
-function groupByFormation(uai, millesime) {
+function groupByCertification(additionalData = {}) {
   return accumulateData(
     (acc, stats) => {
       const dimension = stats.dimensions[0];
@@ -28,10 +28,9 @@ function groupByFormation(uai, millesime) {
 
       if (index === -1) {
         acc.push({
-          uai,
-          code_certification: code,
-          millesime,
+          ...additionalData,
           filiere: getFiliere(dimension),
+          code_certification: code,
           [stats.id_mesure]: stats.valeur_mesure,
         });
       } else {
@@ -44,28 +43,38 @@ function groupByFormation(uai, millesime) {
   );
 }
 
-function groupByCertification(millesime) {
-  return accumulateData(
-    (acc, stats) => {
-      const dimension = stats.dimensions[0];
-      const code = getCodeCertification(dimension);
-      const index = acc.findIndex((item) => item.code_certification === code);
+function computeMissingStats() {
+  return transformData((data) => {
+    const { nb_annee_term, nb_sortant, nb_poursuite_etudes } = data;
 
-      if (index === -1) {
-        acc.push({
-          millesime,
-          filiere: getFiliere(dimension),
-          code_certification: code,
-          [stats.id_mesure]: stats.valeur_mesure,
-        });
-      } else {
-        acc[index][stats.id_mesure] = stats.valeur_mesure;
-      }
+    if (nb_annee_term === undefined || (nb_sortant === undefined && nb_poursuite_etudes === undefined)) {
+      return data;
+    }
 
-      return acc;
-    },
-    { accumulator: [] }
+    return {
+      ...data,
+      // On ne calcul pas le nb_poursuite_etudes, il peut y avoir des sortant pas pris en compte dans nb_sortant
+      //nb_poursuite_etudes: nb_poursuite_etudes === undefined ? nb_annee_term - nb_sortant : nb_poursuite_etudes,
+      nb_sortant: nb_sortant === undefined ? nb_annee_term - nb_poursuite_etudes : nb_sortant,
+    };
+  });
+}
+
+async function transformApiStats(statsFromApi, groupBy) {
+  let stats = [];
+  await oleoduc(
+    Readable.from([statsFromApi]),
+    streamNestedJsonArray("data"),
+    filterFormationStats(),
+    groupBy,
+    flattenArray(),
+    computeMissingStats(),
+    writeData((data) => {
+      stats.push(data);
+    })
   );
+
+  return stats;
 }
 
 class InserJeunes {
@@ -79,37 +88,13 @@ class InserJeunes {
   async getFormationsStats(uai, millesime) {
     const etablissementsStats = await this.api.fetchEtablissementStats(uai, millesime);
 
-    let stats = [];
-    await oleoduc(
-      Readable.from([etablissementsStats]),
-      streamNestedJsonArray("data"),
-      filterFormationStats(),
-      groupByFormation(uai, millesime),
-      flattenArray(),
-      writeData((data) => {
-        stats.push(data);
-      })
-    );
-
-    return stats;
+    return await transformApiStats(etablissementsStats, groupByCertification({ uai, millesime }));
   }
 
   async getCertificationsStats(millesime, filiere) {
     const certificationsStats = await this.api.fetchCertificationStats(millesime, filiere);
 
-    let stats = [];
-    await oleoduc(
-      Readable.from([certificationsStats]),
-      streamNestedJsonArray("data"),
-      filterFormationStats(),
-      groupByCertification(millesime, filiere),
-      flattenArray(),
-      writeData((data) => {
-        stats.push(data);
-      })
-    );
-
-    return stats;
+    return await transformApiStats(certificationsStats, groupByCertification({ millesime }));
   }
 }
 

--- a/server/src/common/stats.js
+++ b/server/src/common/stats.js
@@ -36,7 +36,7 @@ export const TAUX = /^taux_.*$/;
 export const VALEURS = /^nb_.*$/;
 
 export function getMillesimes() {
-  return ["2018_2019", "2019_2020"];
+  return ["2018_2019", "2019_2020", "2020_2021"];
 }
 
 function divide({ dividend, divisor }) {

--- a/server/src/common/stats.js
+++ b/server/src/common/stats.js
@@ -1,4 +1,6 @@
-import { isNil } from "lodash-es";
+import { isNil, mapValues, flow, merge } from "lodash-es";
+import { transformData } from "oleoduc";
+
 import { $field, $percentage, $sumOf } from "./utils/mongodbUtils.js";
 import { omitNil } from "./utils/objectUtils.js";
 import { percentage } from "./utils/numberUtils.js";
@@ -37,6 +39,10 @@ export const TAUX = /^taux_.*$/;
 export const VALEURS = /^nb_.*$/;
 
 export function getMillesimes() {
+  return ["2019", "2020", "2021"];
+}
+
+export function getFormationMillesimes() {
   return ["2018_2019", "2019_2020", "2020_2021"];
 }
 
@@ -183,8 +189,43 @@ export async function getFilieresStats(collection, cfd, millesime) {
     .limit(1)
     .toArray();
 
-  return omitNil({
-    pro: results[0]?.stats?.find((s) => s.filiere === "pro"),
-    apprentissage: results[0]?.stats?.find((s) => s.filiere === "apprentissage"),
-  });
+  return mapValues(
+    omitNil({
+      pro: results[0]?.stats?.find((s) => s.filiere === "pro"),
+      apprentissage: results[0]?.stats?.find((s) => s.filiere === "apprentissage"),
+    }),
+    transformDisplayStat()
+  );
+}
+
+function transformDisplayStatRules() {
+  const rules = [
+    {
+      // Remplace les taux par null si le nbr en année terminales < 20
+      cond: (data) => data.nb_annee_term < 20,
+      transformation: (data) => mapValues(data, (o, k) => (TAUX.test(k) ? null : o)),
+      message: (data) =>
+        merge(data, {
+          _meta: {
+            messages: [
+              `Les taux ne peuvent pas être affichés car il n'y a pas assez d'élèves pour fournir une information fiable.`,
+            ],
+          },
+        }),
+    },
+  ];
+
+  return rules;
+}
+
+export function transformDisplayStat(isStream = false) {
+  const ruleToFunc = ({ cond, transformation, message }) => {
+    return (data) => (cond(data) ? flow(transformation, message)(data) : data);
+  };
+  const rules = transformDisplayStatRules().map(ruleToFunc);
+
+  if (!isStream) {
+    return flow(rules);
+  }
+  return transformData((data) => flow(rules)(data));
 }

--- a/server/src/common/utils/mongodbUtils.js
+++ b/server/src/common/utils/mongodbUtils.js
@@ -8,19 +8,19 @@ export function $sumOf(field) {
 
 export function $percentage(dividend, divisor) {
   return {
-    $cond: [
-      { $or: [{ $eq: [divisor, 0] }, { $not: [divisor] }] },
-      "$$REMOVE",
-      {
-        $round: {
-          $multiply: [
-            {
-              $divide: [dividend, divisor],
-            },
-            100,
-          ],
+    $round: {
+      $multiply: [
+        {
+          $divide: [dividend, divisor],
         },
-      },
-    ],
+        100,
+      ],
+    },
+  };
+}
+
+export function $removeNullOrZero(field, expr) {
+  return {
+    $cond: [{ $or: [{ $eq: [field, 0] }, { $not: [field] }] }, "$$REMOVE", expr],
   };
 }

--- a/server/src/common/utils/numberUtils.js
+++ b/server/src/common/utils/numberUtils.js
@@ -1,3 +1,6 @@
 export function percentage(dividend, divisor) {
-  return Math.round((dividend / divisor) * 100);
+  // Round like mongodb, when X.5 round to the nearest even
+  // Avoid having rate > 100 when additioning 2 percentages rounded
+  const percent = Math.round((dividend / divisor) * 100);
+  return percent - (percent % 2);
 }

--- a/server/src/common/utils/objectUtils.js
+++ b/server/src/common/utils/objectUtils.js
@@ -1,4 +1,4 @@
-import { pickBy, isNil, sortBy, isArray, isEmpty, isNumber } from "lodash-es";
+import { pickBy, isNil, sortBy, isArray } from "lodash-es";
 
 export function omitNil(obj) {
   if (isArray(obj)) {
@@ -6,12 +6,6 @@ export function omitNil(obj) {
   }
 
   return pickBy(obj, (v) => !isNil(v));
-}
-
-export function omitEmpty(obj) {
-  return pickBy(obj, (v) => {
-    return isNumber(v) || !isEmpty(v);
-  });
 }
 
 export function mergeArray(existingArray, newArray, discriminator, options = {}) {

--- a/server/src/http/routes/certificationsRoutes.js
+++ b/server/src/http/routes/certificationsRoutes.js
@@ -11,7 +11,7 @@ import { addCsvHeaders, addJsonHeaders, sendFilieresStats, sendStats } from "../
 import { compose, transformIntoCSV, transformIntoJSON } from "oleoduc";
 import Boom from "boom";
 import { findCodeFormationDiplome } from "../../common/bcn.js";
-import { getFilieresStats } from "../../common/stats.js";
+import { getFilieresStats, transformDisplayStat } from "../../common/stats.js";
 import { getStatsAsColumns } from "../../common/utils/csvUtils.js";
 
 export default () => {
@@ -51,6 +51,7 @@ export default () => {
             millesime: (f) => f.millesime,
             ...getStatsAsColumns(),
           },
+          mapper: (v) => (v === null ? "null" : v),
         });
       } else {
         addJsonHeaders(res);
@@ -62,7 +63,7 @@ export default () => {
         });
       }
 
-      return compose(find.stream(), extensionTransformer, res);
+      return compose(find.stream(), transformDisplayStat(true), extensionTransformer, res);
     })
   );
 
@@ -96,7 +97,7 @@ export default () => {
         throw Boom.notFound("Certification inconnue");
       }
 
-      const stats = results[0];
+      const stats = transformDisplayStat()(results[0]);
       return sendStats("certification", stats, res, options);
     })
   );

--- a/server/src/http/routes/formationsRoutes.js
+++ b/server/src/http/routes/formationsRoutes.js
@@ -11,6 +11,7 @@ import Boom from "boom";
 import { compose, transformIntoCSV, transformIntoJSON } from "oleoduc";
 import { formationsStats } from "../../common/db/collections/collections.js";
 import { getStatsAsColumns } from "../../common/utils/csvUtils.js";
+import { transformDisplayStat } from "../../common/stats.js";
 
 export default () => {
   const router = express.Router();
@@ -58,6 +59,7 @@ export default () => {
             millesime: (f) => f.millesime,
             ...getStatsAsColumns(),
           },
+          mapper: (v) => (v === null ? "null" : v),
         });
       } else {
         addJsonHeaders(res);
@@ -69,7 +71,7 @@ export default () => {
         });
       }
 
-      compose(find.stream(), extensionTransformer, res);
+      compose(find.stream(), transformDisplayStat(true), extensionTransformer, res);
     })
   );
 
@@ -101,7 +103,7 @@ export default () => {
         throw Boom.notFound("Formation inconnue");
       }
 
-      const stats = results[0];
+      const stats = transformDisplayStat()(results[0]);
       return sendStats("formation", stats, res, { direction, theme, ext });
     })
   );

--- a/server/src/http/routes/regionalesRoutes.js
+++ b/server/src/http/routes/regionalesRoutes.js
@@ -11,7 +11,7 @@ import { addCsvHeaders, addJsonHeaders, sendFilieresStats, sendStats } from "../
 import { compose, transformIntoCSV, transformIntoJSON } from "oleoduc";
 import Boom from "boom";
 import { findCodeFormationDiplome } from "../../common/bcn.js";
-import { getFilieresStats } from "../../common/stats.js";
+import { getFilieresStats, transformDisplayStat } from "../../common/stats.js";
 import { getStatsAsColumns } from "../../common/utils/csvUtils.js";
 
 export default () => {
@@ -29,6 +29,7 @@ export default () => {
           millesime: (f) => f.millesime,
           ...getStatsAsColumns(),
         },
+        mapper: (v) => (v === null ? "null" : v),
       });
     } else {
       addJsonHeaders(res);
@@ -40,7 +41,7 @@ export default () => {
       });
     }
 
-    return compose(find.stream(), extensionTransformer, res);
+    return compose(find.stream(), transformDisplayStat(true), extensionTransformer, res);
   }
 
   router.get(
@@ -135,7 +136,7 @@ export default () => {
         throw Boom.notFound("Pas de données disponibles");
       }
 
-      const stats = results[0];
+      const stats = transformDisplayStat()(results[0]);
       return sendStats("certification", stats, res, options);
     })
   );

--- a/server/src/http/routes/swagger.yml
+++ b/server/src/http/routes/swagger.yml
@@ -309,7 +309,9 @@ components:
       description: |
         Permet de filtrer la recherche avec un ou plusieurs codes de certification séparés par des virgules ou des |.
 
-        Un code certification peut-être un code formation diplome (CFD) ou un code MEF STATS 11
+        Un code certification peut-être :
+          * un code formation diplome (CFD) pour la voie apprentissage
+          * un code MEFSTATS11 pour la voie professionnelle
       schema:
         type: string
 
@@ -449,7 +451,10 @@ components:
 
     code_certification:
       name: code_certification
-      description: Un code certification peut-être un code formation diplome (CFD) ou un code MEF STATS 11
+      description: | 
+       Un code certification peut-être :
+          * un code formation diplome (CFD) pour la voie apprentissage
+          * un code MEFSTATS11 pour la voie professionnelle
       in: path
       required: true
       schema:
@@ -463,7 +468,9 @@ components:
       description: |
         Plusieurs codes de certification séparés par des virgules ou des |.
 
-        Un code certification peut-être un code formation diplome (CFD) ou un code MEF STATS 11
+        Un code certification peut-être :
+          * un code formation diplome (CFD) pour la voie apprentissage
+          * un code MEFSTATS11 pour la voie professionnelle
       schema:
         type: string
         example: "32221031409|32221033001|23110022133|01033410|44633521"
@@ -662,19 +669,19 @@ components:
           $ref: "#/components/schemas/Meta"
 
   responses:
-    400:
+    '400':
       description: Bad Request
       content:
         application/json:
           schema:
             $ref: "#/components/schemas/Error"
-    401:
+    '401':
       description: L'api key est manquante ou invalide
       content:
         application/json:
           schema:
             $ref: "#/components/schemas/Error"
-    404:
+    '404':
       description: Not Found
       content:
         application/json:

--- a/server/src/http/routes/swagger.yml
+++ b/server/src/http/routes/swagger.yml
@@ -311,7 +311,7 @@ components:
 
         Un code certification peut-être :
           * un code formation diplome (CFD) pour la voie apprentissage
-          * un code MEFSTATS11 pour la voie professionnelle
+          * un code MEFSTAT11 pour la voie professionnelle
       schema:
         type: string
 
@@ -454,7 +454,7 @@ components:
       description: | 
        Un code certification peut-être :
           * un code formation diplome (CFD) pour la voie apprentissage
-          * un code MEFSTATS11 pour la voie professionnelle
+          * un code MEFSTAT11 pour la voie professionnelle
       in: path
       required: true
       schema:
@@ -470,7 +470,7 @@ components:
 
         Un code certification peut-être :
           * un code formation diplome (CFD) pour la voie apprentissage
-          * un code MEFSTATS11 pour la voie professionnelle
+          * un code MEFSTAT11 pour la voie professionnelle
       schema:
         type: string
         example: "32221031409|32221033001|23110022133|01033410|44633521"

--- a/server/src/http/routes/swagger.yml
+++ b/server/src/http/routes/swagger.yml
@@ -508,6 +508,9 @@ components:
       description: Statut de la pagination
     Region:
       type: object
+      required:
+        - code
+        - nom
       properties:
         code:
           type: string
@@ -526,9 +529,26 @@ components:
           type: string
         description:
           type: string
+        messages:
+          description: Informations supplémentaires sur les données
+          type: array
+          items:
+            type: string
+          example: ["Les taux ne peuvent pas être affichés car il n'y a pas assez d'élèves pour fournir une information fiable."]
 
     Certification:
       type: object
+      description: |
+        Statistiques pour une certification.
+
+        Les taux retournés sont :
+          * null quand les effectifs (nb_annee_term) sont < 20
+          * absent si l'on ne peut pas les calculer (données manquantes)
+      required:
+        - millesime
+        - code_certification
+        - filiere
+        - _meta
       properties:
         millesime:
           type: string
@@ -553,27 +573,48 @@ components:
           type: number
         taux_en_emploi_24_mois:
           type: number
+          nullable: true
         taux_en_emploi_18_mois:
           type: number
+          nullable: true
         taux_en_emploi_12_mois:
           type: number
+          nullable: true
         taux_en_emploi_6_mois:
           type: number
+          nullable: true
         taux_en_formation:
           type: number
+          nullable: true
         taux_autres_6_mois:
           type: number
+          nullable: true
         taux_autres_12_mois:
           type: number
+          nullable: true
         taux_autres_18_mois:
           type: number
+          nullable: true
         taux_autres_24_mois:
           type: number
+          nullable: true
         _meta:
           $ref: "#/components/schemas/Meta"
 
     Regionale:
       type: object
+      description: |
+        Statistiques d'une certification pour une région.
+
+        Les taux retournés sont :
+          * null quand les effectifs (nb_annee_term) sont < 20
+          * absent si l'on ne peut pas les calculer (données manquantes)
+      required:
+        - millesime
+        - code_certification
+        - filiere
+        - region
+        - _meta
       properties:
         millesime:
           type: string
@@ -598,22 +639,31 @@ components:
           type: number
         taux_en_emploi_24_mois:
           type: number
+          nullable: true
         taux_en_emploi_18_mois:
           type: number
+          nullable: true
         taux_en_emploi_12_mois:
           type: number
+          nullable: true
         taux_en_emploi_6_mois:
           type: number
+          nullable: true
         taux_en_formation:
           type: number
+          nullable: true
         taux_autres_6_mois:
           type: number
+          nullable: true
         taux_autres_12_mois:
           type: number
+          nullable: true
         taux_autres_18_mois:
           type: number
+          nullable: true
         taux_autres_24_mois:
           type: number
+          nullable: true
         region:
           $ref: "#/components/schemas/Region"
         _meta:
@@ -621,6 +671,19 @@ components:
 
     Formation:
       type: object
+      description: |
+        Statistiques d'une certification pour une formation.
+
+        Les taux retournés sont :
+          * null quand les effectifs (nb_annee_term) sont < 20
+          * absent si l'on ne peut pas les calculer (données manquantes)
+      required:
+        - uai
+        - millesime
+        - code_certification
+        - filiere
+        - region
+        - _meta
       properties:
         uai:
           type: string
@@ -647,22 +710,31 @@ components:
           type: number
         taux_en_emploi_24_mois:
           type: number
+          nullable: true
         taux_en_emploi_18_mois:
           type: number
+          nullable: true
         taux_en_emploi_12_mois:
           type: number
+          nullable: true
         taux_en_emploi_6_mois:
           type: number
+          nullable: true
         taux_en_formation:
           type: number
+          nullable: true
         taux_autres_6_mois:
           type: number
+          nullable: true
         taux_autres_12_mois:
           type: number
+          nullable: true
         taux_autres_18_mois:
           type: number
+          nullable: true
         taux_autres_24_mois:
           type: number
+          nullable: true
         region:
           $ref: "#/components/schemas/Region"
         _meta:
@@ -691,7 +763,7 @@ components:
     CertificationsResponse:
       description: La liste des certifications avec leurs statistiques
       content:
-        "*/*":
+        "application/json":
           schema:
             type: object
             properties:
@@ -705,6 +777,12 @@ components:
                   pagination:
                     $ref: "#/components/schemas/Pagination"
                 description: Informations complémentaires
+        "text/csv; charset=UTF-8":
+          schema:
+            type: string
+            example: |
+              code_certification;filiere;millesime;nb_annee_term;nb_en_emploi_12_mois;nb_en_emploi_18_mois;nb_en_emploi_24_mois;nb_en_emploi_6_mois;nb_poursuite_etudes;nb_sortant;taux_autres_12_mois;taux_autres_18_mois;taux_autres_24_mois;taux_autres_6_mois;taux_en_emploi_12_mois;taux_en_emploi_18_mois;taux_en_emploi_24_mois;taux_en_emploi_6_mois;taux_en_formation;taux_rupture_contrats
+              50034303;apprentissage;2019;9;3;3;3;4;0;9;67;67;67;56;33;33;33;44;0;20
 
     CertificationResponse:
       description: Une certification avec ses statistiques
@@ -716,7 +794,7 @@ components:
     RegionalesResponse:
       description: La liste des statistiques de certifications pour toutes les régions
       content:
-        "*/*":
+        "application/json":
           schema:
             type: object
             properties:
@@ -730,6 +808,13 @@ components:
                   pagination:
                     $ref: "#/components/schemas/Pagination"
                 description: Informations complémentaires
+        "text/csv; charset=UTF-8":
+          schema:
+            type: string
+            example: |
+              region;code_certification;filiere;millesime;nb_annee_term;nb_en_emploi_12_mois;nb_en_emploi_18_mois;nb_en_emploi_24_mois;nb_en_emploi_6_mois;nb_poursuite_etudes;nb_sortant;taux_autres_12_mois;taux_autres_18_mois;taux_autres_24_mois;taux_autres_6_mois;taux_en_emploi_12_mois;taux_en_emploi_18_mois;taux_en_emploi_24_mois;taux_en_emploi_6_mois;taux_en_formation;taux_rupture_contrats
+              Auvergne-Rhône-Alpes;01022103;apprentissage;2018_2019;106;55;48;55;46;38;67;12;19;12;21;52;45;52;43;36;
+
 
     RegionaleResponse:
       description: La liste des statistiques de certifications pour une région
@@ -741,7 +826,7 @@ components:
     FormationsResponse:
       description: La liste des statistiques des formations
       content:
-        "*/*":
+        "application/json":
           schema:
             type: object
             properties:
@@ -755,6 +840,12 @@ components:
                   pagination:
                     $ref: "#/components/schemas/Pagination"
                 description: Informations complémentaires
+        "text/csv; charset=UTF-8":
+          schema:
+            type: string
+            example: |
+              uai;code_certification;filiere;millesime;nb_annee_term;nb_en_emploi_12_mois;nb_en_emploi_18_mois;nb_en_emploi_24_mois;nb_en_emploi_6_mois;nb_poursuite_etudes;nb_sortant;taux_autres_12_mois;taux_autres_18_mois;taux_autres_24_mois;taux_autres_6_mois;taux_en_emploi_12_mois;taux_en_emploi_18_mois;taux_en_emploi_24_mois;taux_en_emploi_6_mois;taux_en_formation;taux_rupture_contrats
+              0010826T;01022103;apprentissage;2019_2020;9;5;;;4;4;5;0;;;11;56;;;44;44;
 
     FormationResponse:
       description: Les statistiques d'une formation

--- a/server/src/jobs/importCertificationsStats.js
+++ b/server/src/jobs/importCertificationsStats.js
@@ -4,7 +4,7 @@ import { flattenArray, oleoduc, transformData, writeData } from "oleoduc";
 import { bcn, certificationsStats } from "../common/db/collections/collections.js";
 import { getLoggerWithContext } from "../common/logger.js";
 import { omitNil } from "../common/utils/objectUtils.js";
-import { computeCustomStats, INSERJEUNES_IGNORED_STATS_NAMES } from "../common/stats.js";
+import { computeCustomStats, getMillesimes, INSERJEUNES_IGNORED_STATS_NAMES } from "../common/stats.js";
 import { omit, pick } from "lodash-es";
 
 const logger = getLoggerWithContext("import");
@@ -12,7 +12,7 @@ const logger = getLoggerWithContext("import");
 export async function importCertificationsStats(options = {}) {
   const jobStats = { created: 0, updated: 0, failed: 0 };
   const ij = options.inserjeunes || new InserJeunes();
-  const millesimes = options.millesimes || ["2019", "2020", "2021"];
+  const millesimes = options.millesimes || getMillesimes();
   const filieres = options.filieres || ["apprentissage", "voie_pro_sco_educ_nat"];
 
   function handleError(e, context = {}) {

--- a/server/src/jobs/importCertificationsStats.js
+++ b/server/src/jobs/importCertificationsStats.js
@@ -12,7 +12,7 @@ const logger = getLoggerWithContext("import");
 export async function importCertificationsStats(options = {}) {
   const jobStats = { created: 0, updated: 0, failed: 0 };
   const ij = options.inserjeunes || new InserJeunes();
-  const millesimes = options.millesimes || ["2019", "2020"];
+  const millesimes = options.millesimes || ["2019", "2020", "2021"];
   const filieres = options.filieres || ["apprentissage", "voie_pro_sco_educ_nat"];
 
   function handleError(e, context = {}) {

--- a/server/src/jobs/importFormationsStats.js
+++ b/server/src/jobs/importFormationsStats.js
@@ -9,7 +9,7 @@ import { bcn, formationsStats } from "../common/db/collections/collections.js";
 import { getLoggerWithContext } from "../common/logger.js";
 import { omitNil } from "../common/utils/objectUtils.js";
 import { findRegionByNom } from "../common/regions.js";
-import { computeCustomStats, getMillesimes, INSERJEUNES_IGNORED_STATS_NAMES } from "../common/stats.js";
+import { computeCustomStats, getFormationMillesimes, INSERJEUNES_IGNORED_STATS_NAMES } from "../common/stats.js";
 
 const logger = getLoggerWithContext("import");
 
@@ -39,7 +39,9 @@ async function convertEtablissementsIntoParameters(millesime) {
 }
 
 async function streamDefaultParameters() {
-  const streams = await Promise.all(getMillesimes().map((millesime) => convertEtablissementsIntoParameters(millesime)));
+  const streams = await Promise.all(
+    getFormationMillesimes().map((millesime) => convertEtablissementsIntoParameters(millesime))
+  );
 
   return mergeStreams(streams);
 }

--- a/server/src/jobs/importStats.js
+++ b/server/src/jobs/importStats.js
@@ -6,7 +6,9 @@ import { computeRegionalesStats } from "./computeRegionalesStats.js";
 
 export async function importStats(options = {}) {
   let stats = options.stats || ["certifications", "formations", "regionales"];
-  const inserjeunes = new InserJeunes(); //Permet de partager le rate limiter entre les deux imports
+
+  const inserjeunesOptions = { apiOptions: { retry: { retries: 5 } } };
+  const inserjeunes = new InserJeunes(inserjeunesOptions); //Permet de partager le rate limiter entre les deux imports
   await inserjeunes.login();
 
   const results = await promiseAllProps({

--- a/server/tests/common/InserJeunesAPI-test.js
+++ b/server/tests/common/InserJeunesAPI-test.js
@@ -61,4 +61,31 @@ describe("InserJeunesApi", () => {
 
     assert.strictEqual(api.access_token, "token-2");
   });
+
+  it("Réessai une requête lorsque l'API renvoi une erreur", async () => {
+    mockInserJeunesApi(
+      (client, responses) => {
+        client
+          .post("/login")
+          .query(() => true)
+          .replyWithError("Error");
+
+        client
+          .post("/login")
+          .query(() => true)
+          .reply(
+            200,
+            responses.login({
+              access_token: "token",
+            })
+          );
+      },
+      { stack: true }
+    );
+
+    let api = new InserJeunesApi({ retry: { retries: 1, factor: 1, minTimeout: 0 } });
+    await api.login();
+
+    assert.strictEqual(api.access_token, "token");
+  });
 });

--- a/server/tests/common/stats-test.js
+++ b/server/tests/common/stats-test.js
@@ -1,5 +1,5 @@
 import assert from "assert";
-import { buildDescription, getStats, filterStatsNames } from "../../src/common/stats.js";
+import { buildDescription, getStats, getStatsCompute, filterStatsNames } from "../../src/common/stats.js";
 
 describe("statsNames", () => {
   it("Permet de lister le nom de stats", () => {
@@ -14,19 +14,55 @@ describe("statsNames", () => {
     assert.ok(!statsNames.includes("nb_en_emploi_24_mois"));
   });
 
-  it("Permet de filtrer et convertir les stats en un objet", () => {
-    const stats = getStats(/^taux/, () => 1);
-    assert.deepStrictEqual(stats, {
-      taux_en_emploi_12_mois: 1,
-      taux_en_emploi_18_mois: 1,
-      taux_en_emploi_24_mois: 1,
-      taux_en_emploi_6_mois: 1,
-      taux_en_formation: 1,
-      taux_autres_6_mois: 1,
-      taux_autres_12_mois: 1,
-      taux_autres_18_mois: 1,
-      taux_autres_24_mois: 1,
-      taux_rupture_contrats: 1,
+  describe("getStatsCompute", () => {
+    it("Enlève les valeurs qui ne sont pas des nombres", () => {
+      const statsNull = getStatsCompute(/^taux/, () => null);
+      assert.deepStrictEqual(statsNull, {});
+
+      const statsString = getStatsCompute(/^taux/, () => NaN);
+      assert.deepStrictEqual(statsString, {});
+    });
+
+    it("Permet de filtrer et convertir les stats de type nombre en un objet", () => {
+      const stats = getStatsCompute(/^taux/, () => 0);
+      assert.deepStrictEqual(stats, {
+        taux_en_emploi_12_mois: 0,
+        taux_en_emploi_18_mois: 0,
+        taux_en_emploi_24_mois: 0,
+        taux_en_emploi_6_mois: 0,
+        taux_en_formation: 0,
+        taux_autres_6_mois: 0,
+        taux_autres_12_mois: 0,
+        taux_autres_18_mois: 0,
+        taux_autres_24_mois: 0,
+        taux_rupture_contrats: 0,
+      });
+    });
+  });
+
+  describe("getStats", () => {
+    it("Enlève les valeurs manquantes", () => {
+      const statsNull = getStats(/^taux/, () => null);
+      assert.deepStrictEqual(statsNull, {});
+
+      const statsZero = getStats(/^taux/, () => 0);
+      assert.deepStrictEqual(statsZero, {});
+    });
+
+    it("Permet de filtrer et convertir les stats en un objet", () => {
+      const stats = getStats(/^taux/, () => ({}));
+      assert.deepStrictEqual(stats, {
+        taux_en_emploi_12_mois: {},
+        taux_en_emploi_18_mois: {},
+        taux_en_emploi_24_mois: {},
+        taux_en_emploi_6_mois: {},
+        taux_en_formation: {},
+        taux_autres_6_mois: {},
+        taux_autres_12_mois: {},
+        taux_autres_18_mois: {},
+        taux_autres_24_mois: {},
+        taux_rupture_contrats: {},
+      });
     });
   });
 

--- a/server/tests/common/stats-test.js
+++ b/server/tests/common/stats-test.js
@@ -1,5 +1,16 @@
 import assert from "assert";
-import { buildDescription, getStats, getStatsCompute, filterStatsNames } from "../../src/common/stats.js";
+import {
+  buildDescription,
+  getStats,
+  getStatsCompute,
+  filterStatsNames,
+  getFilieresStats,
+  transformDisplayStat,
+} from "../../src/common/stats.js";
+
+import { regionalesStats } from "../../src/common/db/collections/collections.js";
+
+import { insertCFD, insertMEF, insertRegionalesStats } from "../utils/fakeData.js";
 
 describe("statsNames", () => {
   it("Permet de lister le nom de stats", () => {
@@ -93,6 +104,247 @@ describe("statsNames", () => {
     assert.deepStrictEqual(description, {
       titre: "Certification 12345",
       details: "Données InserJeunes pour la certification 12345 (BAC filière pro) pour le millesime 2019",
+    });
+  });
+
+  describe("getFilieresStats", () => {
+    it("Retourne les stats pour une filière", async () => {
+      insertCFD({ code_certification: "12345678", code_formation_diplome: "12345678" });
+      insertRegionalesStats({
+        region: { code: "11", nom: "Île-de-France" },
+        code_certification: "12345678",
+        code_formation_diplome: "12345678",
+        filiere: "apprentissage",
+        millesime: "2020",
+        nb_sortant: 45,
+        nb_annee_term: 50,
+        nb_poursuite_etudes: 5,
+        nb_en_emploi_24_mois: 25,
+        nb_en_emploi_18_mois: 25,
+        nb_en_emploi_12_mois: 25,
+        nb_en_emploi_6_mois: 45,
+      });
+      insertMEF({ code_certification: "23830024202", code_formation_diplome: "12345678" });
+      insertRegionalesStats({
+        region: { code: "11", nom: "Île-de-France" },
+        code_certification: "23830024202",
+        code_formation_diplome: "12345678",
+        filiere: "pro",
+        millesime: "2020",
+        nb_sortant: 45,
+        nb_annee_term: 50,
+        nb_poursuite_etudes: 5,
+        nb_en_emploi_24_mois: 25,
+        nb_en_emploi_18_mois: 25,
+        nb_en_emploi_12_mois: 25,
+        nb_en_emploi_6_mois: 45,
+      });
+
+      const result = await getFilieresStats(regionalesStats(), "12345678", "2020");
+      assert.deepStrictEqual(result, {
+        pro: {
+          codes_certifications: ["23830024202"],
+          code_formation_diplome: "12345678",
+          filiere: "pro",
+          millesime: "2020",
+          diplome: { code: "4", libelle: "BAC" },
+          nb_annee_term: 50,
+          nb_en_emploi_12_mois: 25,
+          nb_en_emploi_18_mois: 25,
+          nb_en_emploi_24_mois: 25,
+          nb_en_emploi_6_mois: 45,
+          nb_poursuite_etudes: 5,
+          nb_sortant: 45,
+          taux_autres_12_mois: 40,
+          taux_autres_18_mois: 40,
+          taux_autres_24_mois: 40,
+          taux_autres_6_mois: 0,
+          taux_en_emploi_12_mois: 50,
+          taux_en_emploi_18_mois: 50,
+          taux_en_emploi_24_mois: 50,
+          taux_en_emploi_6_mois: 90,
+          taux_en_formation: 10,
+        },
+        apprentissage: {
+          codes_certifications: ["12345678"],
+          code_formation_diplome: "12345678",
+          filiere: "apprentissage",
+          millesime: "2020",
+          diplome: { code: "4", libelle: "BAC" },
+          nb_annee_term: 50,
+          nb_en_emploi_12_mois: 25,
+          nb_en_emploi_18_mois: 25,
+          nb_en_emploi_24_mois: 25,
+          nb_en_emploi_6_mois: 45,
+          nb_poursuite_etudes: 5,
+          nb_sortant: 45,
+          taux_autres_12_mois: 40,
+          taux_autres_18_mois: 40,
+          taux_autres_24_mois: 40,
+          taux_autres_6_mois: 0,
+          taux_en_emploi_12_mois: 50,
+          taux_en_emploi_18_mois: 50,
+          taux_en_emploi_24_mois: 50,
+          taux_en_emploi_6_mois: 90,
+          taux_en_formation: 10,
+        },
+      });
+    });
+
+    it("Met les taux à null quand les effectifs sont < 20", async () => {
+      insertCFD({ code_certification: "12345678", code_formation_diplome: "12345678" });
+      insertRegionalesStats({
+        region: { code: "11", nom: "Île-de-France" },
+        code_certification: "12345678",
+        code_formation_diplome: "12345678",
+        filiere: "apprentissage",
+        millesime: "2020",
+        nb_annee_term: 10,
+        nb_en_emploi_12_mois: 2,
+        nb_en_emploi_18_mois: 2,
+        nb_en_emploi_24_mois: 2,
+        nb_en_emploi_6_mois: 2,
+        nb_poursuite_etudes: 5,
+        nb_sortant: 5,
+      });
+      insertMEF({ code_certification: "23830024202", code_formation_diplome: "12345678" });
+      insertRegionalesStats({
+        region: { code: "11", nom: "Île-de-France" },
+        code_certification: "23830024202",
+        code_formation_diplome: "12345678",
+        filiere: "pro",
+        millesime: "2020",
+        nb_annee_term: 10,
+        nb_en_emploi_12_mois: 2,
+        nb_en_emploi_18_mois: 2,
+        nb_en_emploi_24_mois: 2,
+        nb_en_emploi_6_mois: 2,
+        nb_poursuite_etudes: 5,
+        nb_sortant: 5,
+      });
+
+      const result = await getFilieresStats(regionalesStats(), "12345678", "2020");
+      assert.deepStrictEqual(result, {
+        pro: {
+          codes_certifications: ["23830024202"],
+          code_formation_diplome: "12345678",
+          filiere: "pro",
+          millesime: "2020",
+          diplome: { code: "4", libelle: "BAC" },
+          nb_annee_term: 10,
+          nb_en_emploi_12_mois: 2,
+          nb_en_emploi_18_mois: 2,
+          nb_en_emploi_24_mois: 2,
+          nb_en_emploi_6_mois: 2,
+          nb_poursuite_etudes: 5,
+          nb_sortant: 5,
+          taux_autres_12_mois: null,
+          taux_autres_18_mois: null,
+          taux_autres_24_mois: null,
+          taux_autres_6_mois: null,
+          taux_en_emploi_12_mois: null,
+          taux_en_emploi_18_mois: null,
+          taux_en_emploi_24_mois: null,
+          taux_en_emploi_6_mois: null,
+          taux_en_formation: null,
+          _meta: {
+            messages: [
+              `Les taux ne peuvent pas être affichés car il n'y a pas assez d'élèves pour fournir une information fiable.`,
+            ],
+          },
+        },
+        apprentissage: {
+          codes_certifications: ["12345678"],
+          code_formation_diplome: "12345678",
+          filiere: "apprentissage",
+          millesime: "2020",
+          diplome: { code: "4", libelle: "BAC" },
+          nb_annee_term: 10,
+          nb_en_emploi_12_mois: 2,
+          nb_en_emploi_18_mois: 2,
+          nb_en_emploi_24_mois: 2,
+          nb_en_emploi_6_mois: 2,
+          nb_poursuite_etudes: 5,
+          nb_sortant: 5,
+          taux_autres_12_mois: null,
+          taux_autres_18_mois: null,
+          taux_autres_24_mois: null,
+          taux_autres_6_mois: null,
+          taux_en_emploi_12_mois: null,
+          taux_en_emploi_18_mois: null,
+          taux_en_emploi_24_mois: null,
+          taux_en_emploi_6_mois: null,
+          taux_en_formation: null,
+          _meta: {
+            messages: [
+              `Les taux ne peuvent pas être affichés car il n'y a pas assez d'élèves pour fournir une information fiable.`,
+            ],
+          },
+        },
+      });
+    });
+  });
+
+  describe("transformDisplayStat", () => {
+    it("Met les taux à null quand les effectifs sont < 20", async () => {
+      const data = {
+        nb_annee_term: 10,
+        taux_autres_12_mois: 0,
+        taux_autres_18_mois: 0,
+        taux_autres_24_mois: 0,
+        taux_autres_6_mois: 0,
+        taux_en_emploi_12_mois: 20,
+        taux_en_emploi_18_mois: 20,
+        taux_en_emploi_24_mois: 20,
+        taux_en_emploi_6_mois: 20,
+        taux_en_formation: 50,
+      };
+      const result = transformDisplayStat()(data);
+      assert.deepStrictEqual(result, {
+        nb_annee_term: 10,
+        taux_autres_12_mois: null,
+        taux_autres_18_mois: null,
+        taux_autres_24_mois: null,
+        taux_autres_6_mois: null,
+        taux_en_emploi_12_mois: null,
+        taux_en_emploi_18_mois: null,
+        taux_en_emploi_24_mois: null,
+        taux_en_emploi_6_mois: null,
+        taux_en_formation: null,
+        _meta: {
+          messages: [
+            `Les taux ne peuvent pas être affichés car il n'y a pas assez d'élèves pour fournir une information fiable.`,
+          ],
+        },
+      });
+    });
+
+    it("Ne change pas les taux  quand les effectifs sont >= 20", async () => {
+      const data = {
+        nb_annee_term: 20,
+        taux_autres_12_mois: 0,
+        taux_autres_18_mois: 0,
+        taux_autres_24_mois: 0,
+        taux_autres_6_mois: 0,
+        taux_en_emploi_12_mois: 20,
+        taux_en_emploi_18_mois: 20,
+        taux_en_emploi_24_mois: 20,
+        taux_en_emploi_6_mois: 20,
+        taux_en_formation: 50,
+      };
+      const result = transformDisplayStat()(data);
+      assert.deepStrictEqual(result, {
+        nb_annee_term: 20,
+        taux_autres_12_mois: 0,
+        taux_autres_18_mois: 0,
+        taux_autres_24_mois: 0,
+        taux_autres_6_mois: 0,
+        taux_en_emploi_12_mois: 20,
+        taux_en_emploi_18_mois: 20,
+        taux_en_emploi_24_mois: 20,
+        taux_en_emploi_6_mois: 20,
+        taux_en_formation: 50,
+      });
     });
   });
 });

--- a/server/tests/http/certificationsRoutes-test.js
+++ b/server/tests/http/certificationsRoutes-test.js
@@ -1,4 +1,4 @@
-import assert from "assert";
+import { assert } from "chai";
 import config from "../../src/config.js";
 import { startServer } from "../utils/testUtils.js";
 import { insertCertificationsStats, insertCFD, insertMEF } from "../utils/fakeData.js";
@@ -142,6 +142,98 @@ describe("certificationsRoutes", () => {
       assert.strictEqual(response.status, 200);
       assert.strictEqual(response.data.certifications[0].code_certification, "12345");
       assert.strictEqual(response.data.pagination.total, 1);
+    });
+
+    it("Vérifie que l'on met les taux à null pour les effectifs < 20", async () => {
+      const { httpClient } = await startServer();
+      await insertCertificationsStats({
+        code_certification: "12345",
+        nb_annee_term: 19,
+        nb_poursuite_etudes: 1,
+        nb_en_emploi_24_mois: 2,
+        nb_en_emploi_18_mois: 3,
+        nb_en_emploi_12_mois: 4,
+        nb_en_emploi_6_mois: 5,
+        nb_sortant: 6,
+        taux_rupture_contrats: 7,
+        taux_en_formation: 8,
+        taux_en_emploi_24_mois: 9,
+        taux_en_emploi_18_mois: 10,
+        taux_en_emploi_12_mois: 11,
+        taux_en_emploi_6_mois: 12,
+        taux_autres_6_mois: 13,
+        taux_autres_12_mois: 14,
+        taux_autres_18_mois: 15,
+        taux_autres_24_mois: 16,
+      });
+
+      const response = await httpClient.get(`/api/inserjeunes/certifications/12345`, {
+        headers: {
+          ...getAuthHeaders(),
+        },
+      });
+
+      assert.strictEqual(response.status, 200);
+      assert.strictEqual(response.data.code_certification, "12345");
+      assert.include(response.data, {
+        taux_rupture_contrats: null,
+        taux_en_formation: null,
+        taux_en_emploi_24_mois: null,
+        taux_en_emploi_18_mois: null,
+        taux_en_emploi_12_mois: null,
+        taux_en_emploi_6_mois: null,
+        taux_autres_6_mois: null,
+        taux_autres_12_mois: null,
+        taux_autres_18_mois: null,
+        taux_autres_24_mois: null,
+      });
+
+      assert.deepNestedInclude(response.data, {
+        "_meta.messages": [
+          `Les taux ne peuvent pas être affichés car il n'y a pas assez d'élèves pour fournir une information fiable.`,
+        ],
+      });
+    });
+
+    it("Vérifie que l'on met les taux à null pour les effectifs < 20 au format CSV", async () => {
+      const { httpClient } = await startServer();
+      await insertCertificationsStats({
+        millesime: "2020",
+        code_certification: "12345678",
+        filiere: "apprentissage",
+        nb_annee_term: 19,
+        nb_poursuite_etudes: 1,
+        nb_en_emploi_24_mois: 2,
+        nb_en_emploi_18_mois: 3,
+        nb_en_emploi_12_mois: 4,
+        nb_en_emploi_6_mois: 5,
+        nb_sortant: 6,
+        taux_rupture_contrats: 7,
+        taux_en_formation: 8,
+        taux_en_emploi_24_mois: 9,
+        taux_en_emploi_18_mois: 10,
+        taux_en_emploi_12_mois: 11,
+        taux_en_emploi_6_mois: 12,
+        taux_autres_6_mois: 13,
+        taux_autres_12_mois: 14,
+        taux_autres_18_mois: 15,
+        taux_autres_24_mois: 16,
+      });
+
+      const response = await httpClient.get(`/api/inserjeunes/certifications.csv`, {
+        headers: {
+          ...getAuthHeaders(),
+        },
+      });
+
+      assert.strictEqual(response.status, 200);
+      assert.strictEqual(response.headers["content-type"], "text/csv; charset=UTF-8");
+      assert.deepStrictEqual(
+        response.data,
+        `code_certification;filiere;millesime;nb_annee_term;nb_en_emploi_12_mois;nb_en_emploi_18_mois;nb_en_emploi_24_mois;nb_en_emploi_6_mois;nb_poursuite_etudes;nb_sortant;taux_autres_12_mois;taux_autres_18_mois;taux_autres_24_mois;taux_autres_6_mois;taux_en_emploi_12_mois;taux_en_emploi_18_mois;taux_en_emploi_24_mois;taux_en_emploi_6_mois;taux_en_formation;taux_rupture_contrats
+12345678;apprentissage;2020;19;4;3;2;5;1;6;null;null;null;null;null;null;null;null;null;null
+`
+      );
     });
 
     it("Vérifie qu'on peut exporter les données au format CSV", async () => {
@@ -420,6 +512,7 @@ describe("certificationsRoutes", () => {
         code_certification: "23830024203",
         filiere: "apprentissage",
         taux_en_formation: 5,
+        nb_annee_term: 20,
       });
 
       const response = await httpClient.get("/api/inserjeunes/certifications/23830024203.svg");

--- a/server/tests/http/certificationsRoutes-test.js
+++ b/server/tests/http/certificationsRoutes-test.js
@@ -737,7 +737,6 @@ describe("certificationsRoutes", () => {
       const response = await httpClient.get("/api/inserjeunes/certifications/12345678|23830024202.svg");
 
       assert.strictEqual(response.status, 200);
-      console.log(response.data);
       assert.ok(response.headers["content-type"].includes("image/svg+xml"));
       assert.ok(response.data.includes("100%"));
       assert.ok(response.data.includes("10%"));

--- a/server/tests/http/formationsRoutes-test.js
+++ b/server/tests/http/formationsRoutes-test.js
@@ -1,4 +1,4 @@
-import assert from "assert";
+import { assert } from "chai";
 import config from "../../src/config.js";
 import { startServer } from "../utils/testUtils.js";
 import { insertFormationsStats } from "../utils/fakeData.js";
@@ -194,6 +194,97 @@ describe("formationsRoutes", () => {
       assert.strictEqual(response.status, 200);
       assert.strictEqual(response.data.formations[0].code_certification, "12345");
       assert.strictEqual(response.data.pagination.total, 1);
+    });
+
+    it("Vérifie que l'on met les taux à null pour les effectifs < 20", async () => {
+      const { httpClient } = await startServer();
+      await insertFormationsStats({
+        uai: "0751234J",
+        code_certification: "12345",
+        nb_annee_term: 19,
+        nb_poursuite_etudes: 1,
+        nb_en_emploi_24_mois: 2,
+        nb_en_emploi_18_mois: 3,
+        nb_en_emploi_12_mois: 4,
+        nb_en_emploi_6_mois: 5,
+        nb_sortant: 6,
+        taux_rupture_contrats: 7,
+        taux_en_formation: 8,
+        taux_en_emploi_24_mois: 9,
+        taux_en_emploi_18_mois: 10,
+        taux_en_emploi_12_mois: 11,
+        taux_en_emploi_6_mois: 12,
+        taux_autres_6_mois: 13,
+        taux_autres_12_mois: 14,
+        taux_autres_18_mois: 15,
+        taux_autres_24_mois: 16,
+      });
+
+      const response = await httpClient.get(`/api/inserjeunes/formations/0751234J-12345`, {
+        headers: {
+          ...getAuthHeaders(),
+        },
+      });
+
+      assert.strictEqual(response.status, 200);
+      assert.strictEqual(response.data.uai, "0751234J");
+      assert.include(response.data, {
+        taux_rupture_contrats: null,
+        taux_en_formation: null,
+        taux_en_emploi_24_mois: null,
+        taux_en_emploi_18_mois: null,
+        taux_en_emploi_12_mois: null,
+        taux_en_emploi_6_mois: null,
+        taux_autres_6_mois: null,
+        taux_autres_12_mois: null,
+        taux_autres_18_mois: null,
+        taux_autres_24_mois: null,
+      });
+      assert.deepNestedInclude(response.data, {
+        "_meta.messages": [
+          `Les taux ne peuvent pas être affichés car il n'y a pas assez d'élèves pour fournir une information fiable.`,
+        ],
+      });
+    });
+
+    it("Vérifie que l'on met les taux à null pour les effectifs < 20 au format CSV", async () => {
+      const { httpClient } = await startServer();
+      await insertFormationsStats({
+        uai: "0751234J",
+        code_certification: "12345678",
+        nb_annee_term: 19,
+        nb_poursuite_etudes: 1,
+        nb_en_emploi_24_mois: 2,
+        nb_en_emploi_18_mois: 3,
+        nb_en_emploi_12_mois: 4,
+        nb_en_emploi_6_mois: 5,
+        nb_sortant: 6,
+        taux_rupture_contrats: 7,
+        taux_en_formation: 8,
+        taux_en_emploi_24_mois: 9,
+        taux_en_emploi_18_mois: 10,
+        taux_en_emploi_12_mois: 11,
+        taux_en_emploi_6_mois: 12,
+        taux_autres_6_mois: 13,
+        taux_autres_12_mois: 14,
+        taux_autres_18_mois: 15,
+        taux_autres_24_mois: 16,
+      });
+
+      const response = await httpClient.get(`/api/inserjeunes/formations.csv`, {
+        headers: {
+          ...getAuthHeaders(),
+        },
+      });
+
+      assert.strictEqual(response.status, 200);
+      assert.strictEqual(response.headers["content-type"], "text/csv; charset=UTF-8");
+      assert.deepStrictEqual(
+        response.data,
+        `uai;code_certification;filiere;millesime;nb_annee_term;nb_en_emploi_12_mois;nb_en_emploi_18_mois;nb_en_emploi_24_mois;nb_en_emploi_6_mois;nb_poursuite_etudes;nb_sortant;taux_autres_12_mois;taux_autres_18_mois;taux_autres_24_mois;taux_autres_6_mois;taux_en_emploi_12_mois;taux_en_emploi_18_mois;taux_en_emploi_24_mois;taux_en_emploi_6_mois;taux_en_formation;taux_rupture_contrats
+0751234J;12345678;apprentissage;2018_2019;19;4;3;2;5;1;6;null;null;null;null;null;null;null;null;null;null
+`
+      );
     });
 
     it("Vérifie qu'on peut exporter les données au format CSV", async () => {
@@ -393,6 +484,7 @@ describe("formationsRoutes", () => {
         uai: "0751234J",
         code_certification: "1022105",
         taux_en_emploi_6_mois: 50,
+        nb_annee_term: 20,
       });
     }
 
@@ -429,7 +521,12 @@ describe("formationsRoutes", () => {
     it("Vérifie qu'on peut obtenir une image SVG avec une seule donnée disponible (vertical)", async () => {
       const { httpClient } = await startServer();
       await formationsStats().insertOne(
-        newFormationStats({ uai: "0751234J", code_certification: "1022105", taux_en_emploi_6_mois: 50 })
+        newFormationStats({
+          uai: "0751234J",
+          code_certification: "1022105",
+          nb_annee_term: 20,
+          taux_en_emploi_6_mois: 50,
+        })
       );
 
       const response = await httpClient.get("/api/inserjeunes/formations/0751234J-1022105.svg");
@@ -443,7 +540,12 @@ describe("formationsRoutes", () => {
     it("Vérifie qu'on peut obtenir une image SVG avec une seule donnée disponible (horizontale)", async () => {
       const { httpClient } = await startServer();
       await formationsStats().insertOne(
-        newFormationStats({ uai: "0751234J", code_certification: "1022105", taux_en_emploi_6_mois: 50 })
+        newFormationStats({
+          uai: "0751234J",
+          code_certification: "1022105",
+          nb_annee_term: 20,
+          taux_en_emploi_6_mois: 50,
+        })
       );
 
       const response = await httpClient.get("/api/inserjeunes/formations/0751234J-1022105.svg?direction=horizontal");
@@ -462,6 +564,7 @@ describe("formationsRoutes", () => {
         newFormationStats({
           uai: "0751234J",
           code_certification: "1022105",
+          nb_annee_term: 20,
           taux_en_formation: 0,
           taux_en_emploi_6_mois: 50,
         })

--- a/server/tests/jobs/importFormationsStats-test.js
+++ b/server/tests/jobs/importFormationsStats-test.js
@@ -1,4 +1,4 @@
-import assert from "assert";
+import { assert } from "chai";
 import { omit, pickBy } from "lodash-es";
 import { importFormationsStats } from "../../src/jobs/importFormationsStats.js";
 import { mockInserJeunesApi } from "../utils/apiMocks.js";
@@ -124,6 +124,122 @@ describe("importFormationsStats", () => {
     });
     assert.ok(found._meta.date_import);
     assert.deepStrictEqual(stats, { created: 1, failed: 0, updated: 0 });
+  });
+
+  describe("Vérifie que l'on calcule les nombres manquants quand cela est possible", () => {
+    it("Ne calcule pas le nb_annee_term si on a le nb_poursuite_etudes et le nb_sortant", async () => {
+      mockApi("0751234J", "2018_2019", {
+        data: [
+          {
+            id_mesure: "nb_poursuite_etudes",
+            valeur_mesure: 27,
+            dimensions: [
+              {
+                id_mefstat11: "12345678900",
+              },
+            ],
+          },
+          {
+            id_mesure: "nb_sortant",
+            valeur_mesure: 9,
+            dimensions: [
+              {
+                id_mefstat11: "12345678900",
+              },
+            ],
+          },
+        ],
+      });
+      await insertMEF({
+        code_certification: "12345678900",
+        code_formation_diplome: "12345678",
+        diplome: { code: "4", libelle: "BAC" },
+      });
+
+      await importFormationsStats({
+        parameters: [{ uai: "0751234J", region: "OCCITANIE", millesime: "2018_2019" }],
+      });
+
+      const found = await formationsStats().findOne({}, { projection: { _id: 0 } });
+      assert.include(found, { nb_sortant: 9, nb_poursuite_etudes: 27 });
+      assert.notProperty(found, "nb_annee_term");
+    });
+
+    it("Ne calcule pas le nb_poursuite_etudes si on a le nb_annee_term et le nb_sortant", async () => {
+      mockApi("0751234J", "2018_2019", {
+        data: [
+          {
+            id_mesure: "nb_annee_term",
+            valeur_mesure: 27,
+            dimensions: [
+              {
+                id_mefstat11: "12345678900",
+              },
+            ],
+          },
+          {
+            id_mesure: "nb_sortant",
+            valeur_mesure: 9,
+            dimensions: [
+              {
+                id_mefstat11: "12345678900",
+              },
+            ],
+          },
+        ],
+      });
+      await insertMEF({
+        code_certification: "12345678900",
+        code_formation_diplome: "12345678",
+        diplome: { code: "4", libelle: "BAC" },
+      });
+
+      await importFormationsStats({
+        parameters: [{ uai: "0751234J", region: "OCCITANIE", millesime: "2018_2019" }],
+      });
+
+      const found = await formationsStats().findOne({}, { projection: { _id: 0 } });
+      assert.include(found, { nb_annee_term: 27, nb_sortant: 9 });
+      assert.notProperty(found, "nb_poursuite_etudes");
+      assert.notProperty(found, "taux_en_formation");
+    });
+
+    it("Calcule le nb_sortant si on a le nb_annee_term et nb_poursuite_etudes", async () => {
+      mockApi("0751234J", "2018_2019", {
+        data: [
+          {
+            id_mesure: "nb_annee_term",
+            valeur_mesure: 27,
+            dimensions: [
+              {
+                id_mefstat11: "12345678900",
+              },
+            ],
+          },
+          {
+            id_mesure: "nb_poursuite_etudes",
+            valeur_mesure: 9,
+            dimensions: [
+              {
+                id_mefstat11: "12345678900",
+              },
+            ],
+          },
+        ],
+      });
+      await insertMEF({
+        code_certification: "12345678900",
+        code_formation_diplome: "12345678",
+        diplome: { code: "4", libelle: "BAC" },
+      });
+
+      await importFormationsStats({
+        parameters: [{ uai: "0751234J", region: "OCCITANIE", millesime: "2018_2019" }],
+      });
+
+      const found = await formationsStats().findOne({}, { projection: { _id: 0 } });
+      assert.include(found, { nb_annee_term: 27, nb_sortant: 18, nb_poursuite_etudes: 9 });
+    });
   });
 
   it("Vérifie qu'on recalcule les taux", async () => {

--- a/server/tests/utils/apiMocks.js
+++ b/server/tests/utils/apiMocks.js
@@ -20,96 +20,106 @@ export function mockInserJeunesApi(callback, options) {
       );
     },
     uai(custom = {}) {
-      return Object.assign(
-        {},
-        {
-          metadata: {
-            liste_mesures: [
-              {
-                id_mesure: "taux_emploi_12_mois",
-                libelle_mesure: "Taux d emploi salarié en France à 12 mois",
-                unite: "pourcentage",
-              },
-              {
-                id_mesure: "taux_emploi_6_mois",
-                libelle_mesure: "Taux d emploi salarié en France à 6 mois",
-                unite: "pourcentage",
-              },
-            ],
-            liste_dimensions: [
-              {
-                id_moda_dim: 1,
-                id_moda_dim_parent: null,
-                id_dimension: "id_formation_apprentissage",
-                libelle_dimension: "spécialité de formation (apprentissage)",
-                id_modalite: "35011402",
-                libelle_modalite: "statistique et informatique decisionnelle",
-              },
-            ],
-            UAI: {
-              id_uai_etab: "0751234J",
-              libelle_etab: "Centre de formation",
-              adresse_etab_voie: "31 rue des lilas",
-              adresse_etab_localite: "Paris",
-              adresse_etab_code_postal: "75019",
-            },
-          },
-          data: [
+      // L'API inserjeunes retourne un json dans un json
+      return JSON.stringify(
+        JSON.stringify(
+          Object.assign(
+            {},
             {
-              id_mesure: "taux_emploi_6_mois",
-              valeur_mesure: 6,
-              dimensions: [
+              metadata: {
+                liste_mesures: [
+                  {
+                    id_mesure: "taux_emploi_12_mois",
+                    libelle_mesure: "Taux d emploi salarié en France à 12 mois",
+                    unite: "pourcentage",
+                  },
+                  {
+                    id_mesure: "taux_emploi_6_mois",
+                    libelle_mesure: "Taux d emploi salarié en France à 6 mois",
+                    unite: "pourcentage",
+                  },
+                ],
+                liste_dimensions: [
+                  {
+                    id_moda_dim: 1,
+                    id_moda_dim_parent: null,
+                    id_dimension: "id_formation_apprentissage",
+                    libelle_dimension: "spécialité de formation (apprentissage)",
+                    id_modalite: "35011402",
+                    libelle_modalite: "statistique et informatique decisionnelle",
+                  },
+                ],
+                UAI: {
+                  id_uai_etab: "0751234J",
+                  libelle_etab: "Centre de formation",
+                  adresse_etab_voie: "31 rue des lilas",
+                  adresse_etab_localite: "Paris",
+                  adresse_etab_code_postal: "75019",
+                },
+              },
+              data: [
                 {
-                  id_formation_apprentissage: generateCodeCertification(),
+                  id_mesure: "taux_emploi_6_mois",
+                  valeur_mesure: 6,
+                  dimensions: [
+                    {
+                      id_formation_apprentissage: generateCodeCertification(),
+                    },
+                  ],
                 },
               ],
             },
-          ],
-        },
-        custom
+            custom
+          )
+        )
       );
     },
     certifications(custom = {}) {
-      return Object.assign(
-        {},
-        {
-          metadata: {
-            liste_mesures: [
-              {
-                id_mesure: "taux_emploi_6_mois",
-                libelle_mesure: "Taux d emploi salarié en France à 6 mois",
-                unite: "pourcentage",
-              },
-              {
-                id_mesure: "taux_poursuite_etudes",
-                libelle_mesure: "Taux de poursuite d études",
-                unite: "pourcentage",
-              },
-            ],
-            liste_dimensions: [
-              {
-                id_moda_dim: 947,
-                id_moda_dim_parent: 39,
-                id_dimension: "id_formation_apprentissage",
-                libelle_dimension: "spécialité de formation (apprentissage)",
-                id_modalite: "56033104",
-                libelle_modalite: "ambulancier",
-              },
-            ],
-          },
-          data: [
+      // L'API inserjeunes retourne un json dans un json
+      return JSON.stringify(
+        JSON.stringify(
+          Object.assign(
+            {},
             {
-              id_mesure: "taux_emploi_6_mois",
-              valeur_mesure: 6,
-              dimensions: [
+              metadata: {
+                liste_mesures: [
+                  {
+                    id_mesure: "taux_emploi_6_mois",
+                    libelle_mesure: "Taux d emploi salarié en France à 6 mois",
+                    unite: "pourcentage",
+                  },
+                  {
+                    id_mesure: "taux_poursuite_etudes",
+                    libelle_mesure: "Taux de poursuite d études",
+                    unite: "pourcentage",
+                  },
+                ],
+                liste_dimensions: [
+                  {
+                    id_moda_dim: 947,
+                    id_moda_dim_parent: 39,
+                    id_dimension: "id_formation_apprentissage",
+                    libelle_dimension: "spécialité de formation (apprentissage)",
+                    id_modalite: "56033104",
+                    libelle_modalite: "ambulancier",
+                  },
+                ],
+              },
+              data: [
                 {
-                  id_formation_apprentissage: generateCodeCertification(),
+                  id_mesure: "taux_emploi_6_mois",
+                  valeur_mesure: 6,
+                  dimensions: [
+                    {
+                      id_formation_apprentissage: generateCodeCertification(),
+                    },
+                  ],
                 },
               ],
             },
-          ],
-        },
-        custom
+            custom
+          )
+        )
       );
     },
   });

--- a/server/tests/utils/fakeData.js
+++ b/server/tests/utils/fakeData.js
@@ -8,7 +8,7 @@ import {
   formationsStats,
   regionalesStats,
 } from "../../src/common/db/collections/collections.js";
-import { ALL, getStats } from "../../src/common/stats.js";
+import { ALL, getStatsCompute } from "../../src/common/stats.js";
 
 function createCodeFormationDiplome() {
   return faker.helpers.replaceSymbols("4#######");
@@ -24,7 +24,7 @@ export function insertCertificationsStats(custom = {}) {
         code_formation_diplome: createCodeFormationDiplome(),
         diplome: { code: "4", libelle: "BAC" },
         filiere: "apprentissage",
-        ...getStats(ALL, () => generateStatValue()),
+        ...getStatsCompute(ALL, () => generateStatValue()),
         _meta: {
           date_import: new Date(),
         },
@@ -45,7 +45,7 @@ export function insertRegionalesStats(custom = {}) {
         code_certification: generateCodeCertification("4"),
         code_formation_diplome: createCodeFormationDiplome(),
         diplome: { code: "4", libelle: "BAC" },
-        ...getStats(ALL, () => generateStatValue()),
+        ...getStatsCompute(ALL, () => generateStatValue()),
         _meta: {
           date_import: new Date(),
         },
@@ -66,7 +66,7 @@ export function insertFormationsStats(custom = {}) {
         code_certification: generateCodeCertification("4"),
         code_formation_diplome: createCodeFormationDiplome(),
         diplome: { code: "4", libelle: "BAC" },
-        ...getStats(ALL, () => generateStatValue()),
+        ...getStatsCompute(ALL, () => generateStatValue()),
         region: { code: "11", nom: "Île-de-France" },
         _meta: {
           date_import: new Date(),

--- a/server/tests/utils/mochaReporter.cjs
+++ b/server/tests/utils/mochaReporter.cjs
@@ -1,9 +1,11 @@
+// Due to mocha esm limitation on custom reporter, must be a commonJS module
+// https://mochajs.org/#nodejs-native-esm-support
 const util = require("util");
-const Mocha = require("mocha"); // eslint-disable-line node/no-unpublished-require
-const chalk = require("chalk"); // eslint-disable-line node/no-unpublished-require
+const Mocha = require("mocha");
+const chalk = require("chalk");
 const { Base, Spec } = Mocha.reporters;
 const { inherits } = require("util");
-const prettyMilliseconds = require("pretty-ms"); // eslint-disable-line node/no-unpublished-require
+const prettyMilliseconds = require("pretty-ms");
 const color = Base.color;
 const {
   EVENT_RUN_BEGIN,

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -514,6 +514,11 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
   integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
 
+assertion-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
+  integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
+
 astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
@@ -793,6 +798,19 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
+chai@4.3.7:
+  version "4.3.7"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.7.tgz#ec63f6df01829088e8bf55fca839bcd464a8ec51"
+  integrity sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==
+  dependencies:
+    assertion-error "^1.1.0"
+    check-error "^1.0.2"
+    deep-eql "^4.1.2"
+    get-func-name "^2.0.0"
+    loupe "^2.3.1"
+    pathval "^1.1.1"
+    type-detect "^4.0.5"
+
 chalk@4.1.2, chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
@@ -814,6 +832,11 @@ chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
+
+check-error@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
+  integrity sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==
 
 chokidar@3.5.3, chokidar@^3.5.2:
   version "3.5.3"
@@ -1101,6 +1124,13 @@ decompress-response@^3.3.0:
   integrity sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=
   dependencies:
     mimic-response "^1.0.0"
+
+deep-eql@^4.1.2:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-4.1.3.tgz#7c7775513092f7df98d8df9996dd085eb668cc6d"
+  integrity sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==
+  dependencies:
+    type-detect "^4.0.0"
 
 deep-extend@^0.6.0:
   version "0.6.0"
@@ -1775,6 +1805,11 @@ get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
+
+get-func-name@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
+  integrity sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==
 
 get-intrinsic@^1.0.2:
   version "1.1.1"
@@ -2545,6 +2580,13 @@ log-update@^4.0.0:
     slice-ansi "^4.0.0"
     wrap-ansi "^6.2.0"
 
+loupe@^2.3.1:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/loupe/-/loupe-2.3.6.tgz#76e4af498103c532d1ecc9be102036a21f787b53"
+  integrity sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==
+  dependencies:
+    get-func-name "^2.0.0"
+
 lowercase-keys@^1.0.0, lowercase-keys@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
@@ -3149,6 +3191,11 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
+
+pathval@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
+  integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
 
 pause@0.0.1:
   version "0.0.1"
@@ -4015,6 +4062,11 @@ type-check@^0.4.0, type-check@~0.4.0:
   integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
   dependencies:
     prelude-ls "^1.2.1"
+
+type-detect@^4.0.0, type-detect@^4.0.5:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
+  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
 type-fest@^0.20.2:
   version "0.20.2"

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -1316,13 +1316,13 @@ eslint-plugin-es@^3.0.0:
     eslint-utils "^2.0.0"
     regexpp "^3.0.0"
 
-eslint-plugin-mocha@10.0.4:
-  version "10.0.4"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-mocha/-/eslint-plugin-mocha-10.0.4.tgz#b129a1aef8312e8ceaf1b35ff0367f93e917d90a"
-  integrity sha512-8wzAeepVY027oBHz/TmBmUr7vhVqoC1KTFeDybFLhbaWKx+aQ7fJJVuUsqcUy+L+G+XvgQBJY+cbAf7hl5DF7Q==
+eslint-plugin-mocha@10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-mocha/-/eslint-plugin-mocha-10.1.0.tgz#69325414f875be87fb2cb00b2ef33168d4eb7c8d"
+  integrity sha512-xLqqWUF17llsogVOC+8C6/jvQ+4IoOREbN7ZCHuOHuD6cT5cDD4h7f2LgsZuzMAiwswWE21tO7ExaknHVDrSkw==
   dependencies:
     eslint-utils "^3.0.0"
-    ramda "^0.28.0"
+    rambda "^7.1.0"
 
 eslint-plugin-node@11.1.0:
   version "11.1.0"
@@ -3286,10 +3286,10 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.3.tgz#3aeeffc91967ef6e35c0e488ef46fb296ab76aad"
   integrity sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==
 
-ramda@^0.28.0:
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.28.0.tgz#acd785690100337e8b063cab3470019be427cc97"
-  integrity sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==
+rambda@^7.1.0:
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/rambda/-/rambda-7.4.0.tgz#61ec9de31d3dd6affe804de3bae04a5b818781e5"
+  integrity sha512-A9hihu7dUTLOUCM+I8E61V4kRXnN4DwYeK0DwCBydC1MqNI1PidyAtbtpsJlBBzK4icSctEcCQ1bGcLpBuETUQ==
 
 randombytes@^2.1.0:
   version "2.1.0"

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -531,6 +531,13 @@ async-mutex@^0.3.2:
   dependencies:
     tslib "^2.3.1"
 
+async-retry@1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/async-retry/-/async-retry-1.3.3.tgz#0e7f36c04d8478e7a58bdbed80cedf977785f280"
+  integrity sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==
+  dependencies:
+    retry "0.13.1"
+
 async@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.3.tgz#ac53dafd3f4720ee9e8a160628f18ea91df196c9"
@@ -2515,12 +2522,7 @@ lodash.flattendeep@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
   integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
 
-lodash.set@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
-  integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
-
-lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20:
+lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -2848,14 +2850,14 @@ next-tick@1, next-tick@^1.1.0:
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.1.0.tgz#1836ee30ad56d67ef281b22bd199f709449b35eb"
   integrity sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==
 
-nock@13.2.4:
-  version "13.2.4"
-  resolved "https://registry.yarnpkg.com/nock/-/nock-13.2.4.tgz#43a309d93143ee5cdcca91358614e7bde56d20e1"
-  integrity sha512-8GPznwxcPNCH/h8B+XZcKjYPXnUV5clOKCjAqyjsiqA++MpNx9E9+t8YPp0MbThO+KauRo7aZJ1WuIZmOrT2Ug==
+nock@13.3.0:
+  version "13.3.0"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-13.3.0.tgz#b13069c1a03f1ad63120f994b04bfd2556925768"
+  integrity sha512-HHqYQ6mBeiMc+N038w8LkMpDCRquCHWeNmN3v6645P3NhN2+qXOBqvPqo7Rt1VyCMzKhJ733wZqw5B7cQVFNPg==
   dependencies:
     debug "^4.1.0"
     json-stringify-safe "^5.0.1"
-    lodash.set "^4.3.2"
+    lodash "^4.17.21"
     propagate "^2.0.0"
 
 node-preload@^0.2.1:
@@ -3452,6 +3454,11 @@ restore-cursor@^3.1.0:
   dependencies:
     onetime "^5.1.0"
     signal-exit "^3.0.2"
+
+retry@0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
+  integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
 
 rfdc@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION
- Ajout du millésime 2020-2021
- Ajout de retry en cas d'erreur de l'api IJ
- Calcul des nombres manquants quand cela est possible (Ex: Si nb en année terminales  et nb en poursuite d'études, calcul le nb de sortant)
- Ne filtre pas les taux à 0
- Corrige les taux > 100
- Filtre les taux pour les effectifs faibles
- Différencie les taux absents de ceux filtrés.